### PR TITLE
Change type of optchar to int

### DIFF
--- a/src/nvtop.c
+++ b/src/nvtop.c
@@ -158,7 +158,7 @@ int main (int argc, char **argv) {
   bool cache_pid_infos = true;
   bool use_fahrenheit = false;
   while (true) {
-    char optchar = getopt_long(argc, argv, opts, long_opts, NULL);
+    int optchar = getopt_long(argc, argv, opts, long_opts, NULL);
     if (optchar == -1)
       break;
     switch (optchar) {


### PR DESCRIPTION
This ensures that the code works on platforms where char is unsigned.

Fixes Syllo/nvtop#19