### PR TITLE
--no-plot: remove required arg and document in usage

### DIFF
--- a/src/nvtop.c
+++ b/src/nvtop.c
@@ -56,6 +56,7 @@ static const char helpstring[] =
 "  -N --no-cache     : Always query the system for user names and command line information\n"
 "  -f --freedom-unit : Use fahrenheit\n"
 "  -E --encode-hide  : Set encode/decode auto hide time in seconds (default 30s, negative = always on screen)\n"
+"  -p --no-plot      : Disable the maximum line plotting\n"
 "  -h --help         : Print help and exit\n";
 
 static const char versionString[] =

--- a/src/nvtop.c
+++ b/src/nvtop.c
@@ -124,7 +124,7 @@ static const struct option long_opts[] = {
   },
   {
     .name = "no-plot",
-    .has_arg = required_argument,
+    .has_arg = no_argument,
     .flag = NULL,
     .val = 'p'
   },


### PR DESCRIPTION
The man page doesn't document the fact that an argument is required, and it seems more in line with other flags, such as `--no-cache`.

Also, document the option in usage (`--help`)