### PR TITLE
Fix crash bug when build with -DCURSES_NEED_WIDE=TRUE

### DIFF
--- a/cmake/modules/FindCurses.cmake
+++ b/cmake/modules/FindCurses.cmake
@@ -1,46 +1,49 @@
 # Distributed under the OSI-approved BSD 3-Clause License.  See accompanying
 # file Copyright.txt or https://cmake.org/licensing for details.
 
-#.rst:
-# FindCurses
-# ----------
-#
-# Find the curses or ncurses include file and library.
-#
-# Result Variables
-# ^^^^^^^^^^^^^^^^
-#
-# This module defines the following variables:
-#
-# ``CURSES_FOUND``
-#   True if Curses is found.
-# ``CURSES_INCLUDE_DIRS``
-#   The include directories needed to use Curses.
-# ``CURSES_LIBRARIES``
-#   The libraries needed to use Curses.
-# ``CURSES_HAVE_CURSES_H``
-#   True if curses.h is available.
-# ``CURSES_HAVE_NCURSES_H``
-#   True if ncurses.h is available.
-# ``CURSES_HAVE_NCURSES_NCURSES_H``
-#   True if ``ncurses/ncurses.h`` is available.
-# ``CURSES_HAVE_NCURSES_CURSES_H``
-#   True if ``ncurses/curses.h`` is available.
-#
-# Set ``CURSES_NEED_NCURSES`` to ``TRUE`` before the
-# ``find_package(Curses)`` call if NCurses functionality is required.
-# Set ``CURSES_NEED_WIDE`` to ``TRUE`` before the
-# ``find_package(Curses)`` call if unicode functionality is required.
-#
-# Backward Compatibility
-# ^^^^^^^^^^^^^^^^^^^^^^
-#
-# The following variable are provided for backward compatibility:
-#
-# ``CURSES_INCLUDE_DIR``
-#   Path to Curses include.  Use ``CURSES_INCLUDE_DIRS`` instead.
-# ``CURSES_LIBRARY``
-#   Path to Curses library.  Use ``CURSES_LIBRARIES`` instead.
+#[=======================================================================[.rst:
+FindCurses
+----------
+
+Find the curses or ncurses include file and library.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+``CURSES_FOUND``
+  True if Curses is found.
+``CURSES_INCLUDE_DIRS``
+  The include directories needed to use Curses.
+``CURSES_LIBRARIES``
+  The libraries needed to use Curses.
+``CURSES_CFLAGS``
+  Parameters which ought be given to C/C++ compilers when using Curses.
+``CURSES_HAVE_CURSES_H``
+  True if curses.h is available.
+``CURSES_HAVE_NCURSES_H``
+  True if ncurses.h is available.
+``CURSES_HAVE_NCURSES_NCURSES_H``
+  True if ``ncurses/ncurses.h`` is available.
+``CURSES_HAVE_NCURSES_CURSES_H``
+  True if ``ncurses/curses.h`` is available.
+
+Set ``CURSES_NEED_NCURSES`` to ``TRUE`` before the
+``find_package(Curses)`` call if NCurses functionality is required.
+Set ``CURSES_NEED_WIDE`` to ``TRUE`` before the
+``find_package(Curses)`` call if unicode functionality is required.
+
+Backward Compatibility
+^^^^^^^^^^^^^^^^^^^^^^
+
+The following variable are provided for backward compatibility:
+
+``CURSES_INCLUDE_DIR``
+  Path to Curses include.  Use ``CURSES_INCLUDE_DIRS`` instead.
+``CURSES_LIBRARY``
+  Path to Curses library.  Use ``CURSES_LIBRARIES`` instead.
+#]=======================================================================]
 
 include(CheckLibraryExists)
 
@@ -55,7 +58,7 @@ else()
   set(CURSES_NEED_NCURSES TRUE)
 endif()
 
-find_library(CURSES_CURSES_LIBRARY NAMES curses )
+find_library(CURSES_CURSES_LIBRARY NAMES curses)
 
 find_library(CURSES_NCURSES_LIBRARY NAMES "${NCURSES_LIBRARY_NAME}" )
 set(CURSES_USE_NCURSES FALSE)
@@ -117,7 +120,7 @@ if(CURSES_USE_NCURSES)
   if(CURSES_NCURSES_INCLUDE_PATH)
     if (CURSES_NEED_WIDE)
       find_path(CURSES_INCLUDE_PATH
-        NAMES ncursesw/ncurses.h ncursesw/curses.h
+        NAMES ncursesw/ncurses.h ncursesw/curses.h ncursesw.h cursesw.h
         PATHS ${CURSES_NCURSES_INCLUDE_PATH}
         NO_DEFAULT_PATH
         )
@@ -131,16 +134,18 @@ if(CURSES_USE_NCURSES)
   endif()
 
   if (CURSES_NEED_WIDE)
+    set(CURSES_TINFO_LIBRARY_NAME tinfow)
     find_path(CURSES_INCLUDE_PATH
-      NAMES ncursesw/ncurses.h ncursesw/curses.h
+      NAMES ncursesw/ncurses.h ncursesw/curses.h ncursesw.h cursesw.h
       HINTS "${_cursesParentDir}/include"
       )
   else()
+    set(CURSES_TINFO_LIBRARY_NAME tinfo)
     find_path(CURSES_INCLUDE_PATH
       NAMES ncurses/ncurses.h ncurses/curses.h ncurses.h curses.h
       HINTS "${_cursesParentDir}/include"
       )
-   endif()
+  endif()
 
   # Previous versions of FindCurses provided these values.
   if(NOT DEFINED CURSES_LIBRARY)
@@ -150,8 +155,8 @@ if(CURSES_USE_NCURSES)
   CHECK_LIBRARY_EXISTS("${CURSES_NCURSES_LIBRARY}"
     cbreak "" CURSES_NCURSES_HAS_CBREAK)
   if(NOT CURSES_NCURSES_HAS_CBREAK)
-    find_library(CURSES_EXTRA_LIBRARY tinfo HINTS "${_cursesLibDir}")
-    find_library(CURSES_EXTRA_LIBRARY tinfo )
+    find_library(CURSES_EXTRA_LIBRARY "${CURSES_TINFO_LIBRARY_NAME}" HINTS "${_cursesLibDir}")
+    find_library(CURSES_EXTRA_LIBRARY "${CURSES_TINFO_LIBRARY_NAME}" )
   endif()
 else()
   get_filename_component(_cursesLibDir "${CURSES_CURSES_LIBRARY}" PATH)
@@ -237,9 +242,15 @@ if(CURSES_FORM_LIBRARY)
   set(CURSES_LIBRARIES ${CURSES_LIBRARIES} ${CURSES_FORM_LIBRARY})
 endif()
 
-# Provide the *_INCLUDE_DIRS result.
+# Provide the *_INCLUDE_DIRS and *_CFLAGS results.
 set(CURSES_INCLUDE_DIRS ${CURSES_INCLUDE_PATH})
 set(CURSES_INCLUDE_DIR ${CURSES_INCLUDE_PATH}) # compatibility
+
+find_package(PkgConfig QUIET)
+if(PKG_CONFIG_FOUND)
+  pkg_check_modules(NCURSES QUIET ${NCURSES_LIBRARY_NAME})
+  set(CURSES_CFLAGS ${NCURSES_CFLAGS_OTHER})
+endif()
 
 include(FindPackageHandleStandardArgs)
 FIND_PACKAGE_HANDLE_STANDARD_ARGS(Curses DEFAULT_MSG


### PR DESCRIPTION
Fix crash bug when build with libncursesw.so.6 and libtinfow.so.6

The FindCurses.cmake is too old to build with
```-DCURSES_NEED_WIDE=TRUE``` option.
In some latest ENV, always using libncursesw.so.6 and libtinfow.so.6.
The nvtop will crashed with these messages below:

```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==50432==ERROR: AddressSanitizer: SEGV on unknown address 0x0000000000c8 (pc 0x7f9c4d507d39 bp 0x7f9c4d4e6de8 sp 0x7ffc057963a8 T0)
==50432==The signal is caused by a READ memory access.
==50432==Hint: address points to the zero page.
    #0 0x7f9c4d507d38 in termattrs_sp (/lib64/libncursesw.so.6+0x1fd38)
    #1 0x7f9c4d504f73 in _nc_setupscreen_sp (/lib64/libncursesw.so.6+0x1cf73)
    #2 0x7f9c4d50078b in newterm_sp (/lib64/libncursesw.so.6+0x1878b)
    #3 0x7f9c4d500c08 in newterm (/lib64/libncursesw.so.6+0x18c08)
    #4 0x7f9c4d4fca53 in initscr (/lib64/libncursesw.so.6+0x14a53)
    #5 0x55bd7f6d693d in initialize_curses (/usr/local/bin/nvtop+0x5893d)
    #6 0x55bd7f6c9f7a in main (/usr/local/bin/nvtop+0x4bf7a)
    #7 0x7f9c4c998f1a in __libc_start_main (/lib64/libc.so.6+0x23f1a)
    #8 0x55bd7f6ca789 in _start (/usr/local/bin/nvtop+0x4c789)
```

![Screenshot from 2019-10-25 04-40-16](https://user-images.githubusercontent.com/394260/67523607-9b97c480-f6e1-11e9-85b8-1c6baa5dad60.png)


The load library have some problem, NOTE libtinfow.so.6 and
libtinfo.so.6 load at the same time, it is the root cause.

```
ldd /usr/local/bin/nvtop
	linux-vdso.so.1 (0x00007ffca6d82000)
	libasan.so.5 => /usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/libasan.so.5 (0x00007f8823464000)
	libm.so.6 => /lib64/libm.so.6 (0x00007f8823326000)
	libnvidia-ml.so.1 => /usr/lib64/libnvidia-ml.so.1 (0x00007f8822d00000)
	libncursesw.so.6 => /lib64/libncursesw.so.6 (0x00007f8822cc5000)
	libtinfo.so.6 => /lib64/libtinfo.so.6 (0x00007f8822c89000)
	libubsan.so.1 => /usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/libubsan.so.1 (0x00007f8822321000)
	libc.so.6 => /lib64/libc.so.6 (0x00007f8822152000)
	libdl.so.2 => /lib64/libdl.so.2 (0x00007f882214c000)
	librt.so.1 => /lib64/librt.so.1 (0x00007f8822142000)
	libpthread.so.0 => /lib64/libpthread.so.0 (0x00007f8822120000)
	libstdc++.so.6 => /usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/libstdc++.so.6 (0x00007f8821ea8000)
	libgcc_s.so.1 => /usr/lib/gcc/x86_64-pc-linux-gnu/9.2.0/libgcc_s.so.1 (0x00007f8821e8e000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f8823fc5000)
	libtinfow.so.6 => /lib64/libtinfow.so.6 (0x00007f8821e4f000)
```

To fix it, the FindCurses.cmake should using libtinfow.so.6 instead of
libtinfo.so.6 when DCURSES_NEED_WIDE=TRUE. So I updated the
FindCurses.cmake to latest version to fix this problem.

Signed-off-by: Huang Rui <vowstar@gmail.com>