### PR TITLE
Fix: units consistency

### DIFF
--- a/manpage/nvtop.in
+++ b/manpage/nvtop.in
@@ -75,6 +75,10 @@ Sort: Select the field for sorting. The current sort field is highlighted inside
 .BR F10 ", " q ", " Esc
 Quit.
 
+.SH MEMORY SIZES
+.TP
+Memory sizes in nvtop are displayed as multiples of 1024 bytes or 1 KiB.
+
 .SH BUGS
 .TP
 .BR "Some fields are shown as N/A"


### PR DESCRIPTION
Dear Maxime,

Please consider this PR as a small improvement over this great tool. It fixes consistency throughout all units displayed (they're all now multiples of 1024 bytes). Also available/total RAM is displayed with 3 decimal digits.

Thank you.