### PR TITLE
Add columns for per-process GPU, Encoder, and Decoder usage

### DIFF
--- a/include/nvtop/extract_gpuinfo.h
+++ b/include/nvtop/extract_gpuinfo.h
@@ -40,6 +40,9 @@ struct gpu_process {
   size_t cpu_memory_virt;
   size_t cpu_memory_res;
   double cpu_usage;
+  double gpu_usage;
+  double enc_usage;
+  double dec_usage;
 };
 
 enum dev_info_valid {


### PR DESCRIPTION
These stats exist, although they appear to behave strangely. They seem
to take a significant amount of time to rise from zero to the correct
value, although they do seem to eventually converge.