### PR TITLE
Fix: initialize_device_info failed cause double free

### DIFF
--- a/src/extract_gpuinfo.c
+++ b/src/extract_gpuinfo.c
@@ -490,6 +490,7 @@ unsigned int initialize_device_info(struct device_info **dev_info,
         fprintf(stderr, "Impossible to get handle for device number %u : %s\n",
                 i, nvmlErrorString(retval));
         free(*dev_info);
+        *dev_info = NULL;
         return 0;
       }
     } else {

--- a/src/nvtop.c
+++ b/src/nvtop.c
@@ -238,11 +238,13 @@ int main(int argc, char **argv) {
   if (!init_gpu_info_extraction())
     return EXIT_FAILURE;
   size_t num_devices;
-  struct device_info *dev_infos;
+  struct device_info *dev_infos = NULL;
   num_devices = initialize_device_info(&dev_infos, gpu_mask);
   if (num_devices == 0) {
     fprintf(stdout, "No GPU left to monitor.\n");
-    free(dev_infos);
+    if (dev_infos != NULL) {
+      free(dev_infos);
+    }
     return EXIT_SUCCESS;
   }
   size_t biggest_name = 0;


### PR DESCRIPTION
When initialize_device_info failed, it will free allocated memory and return 0. However, the caller might free the memory again and cause a double free problem.