### PR TITLE
Fix: handle empty `/proc/[PID]/cmdline` properly

### DIFF
--- a/src/get_process_info_linux.c
+++ b/src/get_process_info_linux.c
@@ -96,6 +96,10 @@ void get_command_from_pid(pid_t pid, char **buffer) {
   }
   fclose(pid_file);
 
+  if (total_read == 0) {
+    (*buffer)[0] = '\0';
+  }
+
   for (size_t i = 0; total_read && i < total_read - 1; ++i) {
     if ((*buffer)[i] == '\0')
       (*buffer)[i] = ' ';


### PR DESCRIPTION
In some rare cases, the file `/proc/[PID]/cmdline` might be empty. This causes nvtop display wrong information about command being executed or even leak some data inside current memory.

For example, it might leak something similar to `/etc/passwd`.
![image](https://user-images.githubusercontent.com/8341564/117048058-27fa5d00-ad45-11eb-8525-5acf6d6f59b2.png)


I'm not sure how htop or ps handle this kind of case, but I think it's OK to display nothing in command section as it's actually empty there.