### PR TITLE
A spurious fprintf Is breaking layout 

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -1003,7 +1003,6 @@ static void sort_process(all_processes all_procs, enum process_field criterion,
       sort_fun = compare_cpu_mem_usage_desc;
     break;
   case process_gpu_rate:
-    fprintf(stderr, "Comparing gpu rates\n");
     if (asc_sort)
       sort_fun = compare_process_gpu_rate_asc;
     else


### PR DESCRIPTION
Please see "Comparing GPU rates" appearing all over the term GUI in the screenshot below.

<img width="681" alt="ScreenCapture-2021-09-08-15 58 20-iTerm" src="https://user-images.githubusercontent.com/1091114/132596772-48bb359c-190b-420b-848f-83a4e6af5fa8.png">
