### PR TITLE
Add assert in info_in_plot

### DIFF
--- a/src/interface_layout_selection.c
+++ b/src/interface_layout_selection.c
@@ -2,6 +2,7 @@
 #include "nvtop/interface.h"
 #include "nvtop/interface_options.h"
 
+#include <assert.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -86,6 +87,7 @@ static unsigned info_in_plot(unsigned plot_id, unsigned devices_count,
     if (map_device_to_plot[dev_id] == plot_id)
       sum += plot_count_draw_info(to_draw[dev_id]);
   }
+  assert(sum > 0);
   return sum;
 }
 


### PR DESCRIPTION
Makes SIGFPE in compute_sizes_from_layout more obvious.. but
does not actually fix problem

Relates #147

Dunno if this is helpful at all, but at least pinpoints root cause?