### PR TITLE
Link to rt on Linux

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -63,6 +63,9 @@ target_compile_definitions(nvtop PRIVATE _GNU_SOURCE)
 
 target_link_libraries(nvtop
   PRIVATE ncurses m ${CMAKE_DL_LIBS})
+if(UNIX AND NOT APPLE)
+    target_link_libraries(nvtop PRIVATE rt)
+endif()
 
 install (TARGETS nvtop
   RUNTIME DESTINATION bin)


### PR DESCRIPTION
I guess I'm trying to build on some platforms where `rt` isn't linked to automatically. 

I think this is the correct way to get things to work.