### PR TITLE
add gcc-c++ to Fedora instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -128,9 +128,9 @@ Several libraries are required in order for NVTOP to display GPU information:
   - NVIDIA drivers, **CUDA required for nvml libraries** (see [RPM Fusion](https://rpmfusion.org/Howto/NVIDIA))
 
 - NVTOP Dependencies
- - CMake, ncurses and git
+ - CMake, ncurses, c++ and git
   ```bash
-  sudo dnf install cmake ncurses-devel git
+  sudo dnf install cmake ncurses-devel git gcc-c++
   ```
 
 - NVTOP


### PR DESCRIPTION
Making note that you'll the library gcc-c++ is required for cmake to compile this application, even if the "Development  Tools" group is installed on Fedora 36.