### PR TITLE
Fix format-security warnings

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -256,35 +256,35 @@ static void initialize_gpu_mem_plot(struct plot_window *plot, struct window_posi
   char *zeroSec = "0s";
   if (options->plot_left_to_right) {
     char *toPrint = zeroSec;
-    mvwprintw(plot->win, position->sizeY - 1, 4, toPrint);
+    mvwprintw(plot->win, position->sizeY - 1, 4, "%s", toPrint);
 
     int retval = snprintf(elapsedSeconds, 5, "%ds", options->update_interval * cols / 4 / column_divisor / 1000);
     if (retval > 4)
       toPrint = err;
     else
       toPrint = elapsedSeconds;
-    mvwprintw(plot->win, position->sizeY - 1, 4 + cols / 4 - strlen(toPrint) / 2, toPrint);
+    mvwprintw(plot->win, position->sizeY - 1, 4 + cols / 4 - strlen(toPrint) / 2, "%s", toPrint);
 
     retval = snprintf(elapsedSeconds, 5, "%ds", options->update_interval * cols / 2 / column_divisor / 1000);
     if (retval > 4)
       toPrint = err;
     else
       toPrint = elapsedSeconds;
-    mvwprintw(plot->win, position->sizeY - 1, 4 + cols / 2 - strlen(toPrint) / 2, toPrint);
+    mvwprintw(plot->win, position->sizeY - 1, 4 + cols / 2 - strlen(toPrint) / 2, "%s", toPrint);
 
     retval = snprintf(elapsedSeconds, 5, "%ds", options->update_interval * cols * 3 / 4 / column_divisor / 1000);
     if (retval > 4)
       toPrint = err;
     else
       toPrint = elapsedSeconds;
-    mvwprintw(plot->win, position->sizeY - 1, 4 + cols * 3 / 4 - strlen(toPrint) / 2, toPrint);
+    mvwprintw(plot->win, position->sizeY - 1, 4 + cols * 3 / 4 - strlen(toPrint) / 2, "%s", toPrint);
 
     retval = snprintf(elapsedSeconds, 5, "%ds", options->update_interval * cols / column_divisor / 1000);
     if (retval > 4)
       toPrint = err;
     else
       toPrint = elapsedSeconds;
-    mvwprintw(plot->win, position->sizeY - 1, 4 + cols - strlen(toPrint), toPrint);
+    mvwprintw(plot->win, position->sizeY - 1, 4 + cols - strlen(toPrint), "%s", toPrint);
   } else {
     char *toPrint;
     int retval = snprintf(elapsedSeconds, 5, "%ds", options->update_interval * cols / column_divisor / 1000);
@@ -292,31 +292,31 @@ static void initialize_gpu_mem_plot(struct plot_window *plot, struct window_posi
       toPrint = err;
     else
       toPrint = elapsedSeconds;
-    mvwprintw(plot->win, position->sizeY - 1, 4, toPrint);
+    mvwprintw(plot->win, position->sizeY - 1, 4, "%s", toPrint);
 
     retval = snprintf(elapsedSeconds, 5, "%ds", options->update_interval * cols * 3 / 4 / column_divisor / 1000);
     if (retval > 4)
       toPrint = err;
     else
       toPrint = elapsedSeconds;
-    mvwprintw(plot->win, position->sizeY - 1, 4 + cols / 4 - strlen(toPrint) / 2, toPrint);
+    mvwprintw(plot->win, position->sizeY - 1, 4 + cols / 4 - strlen(toPrint) / 2, "%s", toPrint);
 
     retval = snprintf(elapsedSeconds, 5, "%ds", options->update_interval * cols / 2 / column_divisor / 1000);
     if (retval > 4)
       toPrint = err;
     else
       toPrint = elapsedSeconds;
-    mvwprintw(plot->win, position->sizeY - 1, 4 + cols / 2 - strlen(toPrint) / 2, toPrint);
+    mvwprintw(plot->win, position->sizeY - 1, 4 + cols / 2 - strlen(toPrint) / 2, "%s", toPrint);
 
     retval = snprintf(elapsedSeconds, 5, "%ds", options->update_interval * cols / 4 / column_divisor / 1000);
     if (retval > 4)
       toPrint = err;
     else
       toPrint = elapsedSeconds;
-    mvwprintw(plot->win, position->sizeY - 1, 4 + cols * 3 / 4 - strlen(toPrint) / 2, toPrint);
+    mvwprintw(plot->win, position->sizeY - 1, 4 + cols * 3 / 4 - strlen(toPrint) / 2, "%s", toPrint);
 
     toPrint = zeroSec;
-    mvwprintw(plot->win, position->sizeY - 1, 4 + cols - strlen(toPrint), toPrint);
+    mvwprintw(plot->win, position->sizeY - 1, 4 + cols - strlen(toPrint), "%s", toPrint);
   }
   wnoutrefresh(plot->win);
 }


### PR DESCRIPTION
nvtop 2.0.3 fails to build on Arch Linux with `-Werror=format-security` enabled. Let's fix it.