### PR TITLE
Add snap packaging and install instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -173,6 +173,8 @@ Several libraries are required in order for NVTOP to display GPU information:
   snap install nvtop
   snap connect nvtop:hardware-observe
   snap connect nvtop:process-control
+  snap connect nvtop:system-observe
+  snap connect nvtop:kubernetes-support
   ```
 
 ### Docker

--- a/README.markdown
+++ b/README.markdown
@@ -167,6 +167,13 @@ Several libraries are required in order for NVTOP to display GPU information:
   sudo layman -a guru && sudo emerge -av nvtop
   ```
 
+### Snap
+
+- ```bash
+  snap install nvtop
+  snap connect nvtop:hardware-observe
+  ```
+
 ### Docker
 
 - NVIDIA drivers (same as above)

--- a/README.markdown
+++ b/README.markdown
@@ -172,6 +172,7 @@ Several libraries are required in order for NVTOP to display GPU information:
 - ```bash
   snap install nvtop
   snap connect nvtop:hardware-observe
+  snap connect nvtop:process-control
   ```
 
 ### Docker

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,72 @@
+name: nvtop
+base: core22
+adopt-info: nvtop
+summary: 'AMD and NVIDIA GPUs htop like monitoring tool'
+description: |
+  Nvtop stands for Neat Videocard TOP, a (h)top like task monitor for AMD and NVIDIA GPUs. It can handle multiple GPUs and print information about them in a htop familiar way.
+license: GPL-3.0
+grade: stable
+confinement: strict
+architectures:
+- build-on: amd64
+- build-on: arm64
+- build-on: armhf
+- build-on: ppc64el
+- build-on: s390x
+compression: lzo
+apps:
+  nvtop:
+    command: usr/bin/nvtop
+    plugs:
+    - opengl
+    - home
+    - hardware-observe
+layout:
+  /usr/share/libdrm:
+    symlink: $SNAP/usr/share/libdrm
+parts:
+  libdrm:
+    source: https://gitlab.freedesktop.org/mesa/drm.git
+    source-tag: libdrm-2.4.113
+    plugin: meson
+    meson-parameters:
+    - --prefix=/usr
+    - --sysconfdir=/etc
+    - --libdir=lib/$CRAFT_ARCH_TRIPLET
+    - -Dradeon=enabled
+    - -Damdgpu=enabled
+    - -Dudev=true
+    - -Dnouveau=enabled
+    - -Dintel=enabled
+    build-packages:
+    - meson
+    - pkg-config
+    - libudev-dev
+    - libpciaccess-dev
+    prime:
+    - -usr/include
+    - -usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig
+  nvtop:
+    after: [ libdrm ]
+    source: .
+    plugin: cmake
+    cmake-parameters:
+    - -DCMAKE_INSTALL_PREFIX=/usr
+    - -DNVIDIA_SUPPORT=ON
+    - -DAMDGPU_SUPPORT=ON
+    override-pull: |
+      set -eux
+      craftctl default
+      VERSION="$(git describe --tags $(git rev-list --tags --max-count=1))"
+      craftctl set version=$VERSION
+      git checkout $VERSION
+    build-snaps:
+    - cmake
+    build-packages:
+    - gcc
+    - libncurses-dev
+    stage-packages:
+    - libncurses6
+    - libncursesw6
+    prime:
+    - -usr/share/doc

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -22,6 +22,8 @@ apps:
     - home
     - hardware-observe
     - process-control
+    - system-observe
+    - kubernetes-support # Temporarily required for nvtop to display AMD GPU processes. Once apparmor rule to allow access to @{PROC}/[0-9]*/fdinfo/ is added to system-observe, this can be removed.
 layout:
   /usr/share/libdrm:
     symlink: $SNAP/usr/share/libdrm

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -21,6 +21,7 @@ apps:
     - opengl
     - home
     - hardware-observe
+    - process-control
 layout:
   /usr/share/libdrm:
     symlink: $SNAP/usr/share/libdrm


### PR DESCRIPTION
I've added a `snapcraft.yaml`, which builds a snap successfully allowing nvtop to be installed on any Linux distro with snapd installed and be more up to date (as well as its dependencies) than the version that is usually in the distribution repos. Testing the snap locally on my machine shows it working as expected.

To transfer the snap into your ownership you would need to:

1. create a developer account on [Snapcraft.io](https://snapcraft.io/) 
2. I would then add your account as a collaborator on the snap
3. Raise a request on the Snapcraft forum to transfer the snap to you (I can stay on as a collaborator if you wish)

You can then configure in the developer dashboard to have automated builds of the snap when a push is made to the default branch of this repo. The resulting snap will end up on the edge channel, from which it can be promoted to stable on the dashboard after manual testing.

The snap currently needs the `hardware-observe` interface to be connected for AMD GPU fan speeds to be visible and `process-control` to kill processes. I've raised an auto-connect [request](https://forum.snapcraft.io/t/autoconnect-hardware-observe-for-nvtop/31869) on the forum which should hopefully be approved, meaning that on install the snap won't need the user to manually enable the permission.