### PR TITLE
Add Launchpad PPA details

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -127,6 +127,17 @@ A standalone application is available as [AppImage](#appimage).
   sudo apt install nvtop
   ```
 
+#### Ubuntu PPA
+
+A PPA supporting Ubuntu 20.04, 22.04 and newer is provided by
+[Martin Wimpress](https://github.com/flexiondotorg) that offers an up-to-date
+version of `nvtop`, enabled for NVIDIA, AMD and Intel.
+
+```bash
+sudo add-apt-repository ppa:flexiondotorg/nvtop
+sudo apt install nvtop
+```
+
 #### Older
 
 - AMD and Intel Dependencies

--- a/README.markdown
+++ b/README.markdown
@@ -129,7 +129,7 @@ A standalone application is available as [AppImage](#appimage).
 
 #### Ubuntu PPA
 
-A PPA supporting Ubuntu 20.04, 22.04 and newer is provided by
+A [PPA supporting Ubuntu 20.04, 22.04 and newer](https://launchpad.net/~flexiondotorg/+archive/ubuntu/nvtop) is provided by
 [Martin Wimpress](https://github.com/flexiondotorg) that offers an up-to-date
 version of `nvtop`, enabled for NVIDIA, AMD and Intel.
 


### PR DESCRIPTION
I'm maintaining a PPA that provides an up-to-date version of `nvtop` for users of Ubuntu 20.04, 22.04 and newer. `nvtop` builds are enabled for NVIDIA, AMD and Intel.