### PR TITLE
snap: disabling libdrm amdgpu.ids conflicting symlink, enabling intel

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -27,9 +27,9 @@ apps:
     - process-control
     - system-observe
     # - kubernetes-support # Temporarily required for nvtop to display AMD GPU processes. Once apparmor rule to allow access to @{PROC}/[0-9]*/fdinfo/ is added to system-observe, this can be removed.
-layout:
-  /usr/share/libdrm:
-    symlink: $SNAP/usr/share/libdrm
+# layout:
+#   /usr/share/libdrm:
+#     symlink: $SNAP/usr/share/libdrm
 parts:
   libdrm:
     source: https://gitlab.freedesktop.org/mesa/drm.git
@@ -60,6 +60,7 @@ parts:
     - -DCMAKE_INSTALL_PREFIX=/usr
     - -DNVIDIA_SUPPORT=ON
     - -DAMDGPU_SUPPORT=ON
+    - -DINTEL_SUPPORT=ON
     override-pull: |
       set -eux
       craftctl default

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -49,6 +49,8 @@ parts:
     - pkg-config
     - libudev-dev
     - libpciaccess-dev
+    stage-packages:
+    - libpciaccess0
     prime:
     - -usr/include
     - -usr/lib/$CRAFT_ARCH_TRIPLET/pkgconfig


### PR DESCRIPTION
Fixes https://github.com/Syllo/nvtop/issues/173

This amounts to a quick fix for now just to get the snap working again, but in the background I'll carry on trying to get an answer on how to use the nvtop snap's amdgpu.ids over the core22 provided file. This change also enables nvtop to build with intel support enabled.