### PR TITLE
fix multiple gpus selection

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -1788,14 +1788,17 @@ void interface_key(int keyId, struct nvtop_interface *interface) {
       interface->process.option_window.selected_row = 0;
     }
     break;
+  case 'l':
   case KEY_RIGHT:
     if (interface->process.option_window.state == nvtop_option_state_hidden)
       interface->process.offset_column += 4;
     break;
+  case 'h':
   case KEY_LEFT:
     if (interface->process.option_window.state == nvtop_option_state_hidden && interface->process.offset_column >= 4)
       interface->process.offset_column -= 4;
     break;
+  case 'k':
   case KEY_UP:
     switch (interface->process.option_window.state) {
     case nvtop_option_state_kill:
@@ -1811,6 +1814,7 @@ void interface_key(int keyId, struct nvtop_interface *interface) {
       break;
     }
     break;
+  case 'j':
   case KEY_DOWN:
     switch (interface->process.option_window.state) {
     case nvtop_option_state_kill:

--- a/src/interface_options.c
+++ b/src/interface_options.c
@@ -75,8 +75,8 @@ unsigned interface_check_and_fix_monitored_gpus(unsigned num_devices, struct lis
       options->gpu_specific_opts[num_devices - 1] = saveInfo;
     } else {
       numMonitored++;
+      idx++;
     }
-    idx++;
   }
   idx = numMonitored;
   list_for_each_entry_safe(device, list_tmp, nonMonitoredGpu, list) {

--- a/src/interface_options.c
+++ b/src/interface_options.c
@@ -62,7 +62,6 @@ static const char *default_config_path(void) {
 unsigned interface_check_and_fix_monitored_gpus(unsigned num_devices, struct list_head *monitoredGpu,
                                                 struct list_head *nonMonitoredGpu, nvtop_interface_option *options) {
   // The array in options->gpu_specifi_opts is kept in sync with the lists
-  unsigned numMonitored = 0;
   unsigned idx = 0;
   struct gpu_info *device, *list_tmp;
   list_for_each_entry_safe(device, list_tmp, monitoredGpu, list) {
@@ -74,18 +73,17 @@ unsigned interface_check_and_fix_monitored_gpus(unsigned num_devices, struct lis
               (num_devices - idx - 1) * sizeof(*options->gpu_specific_opts));
       options->gpu_specific_opts[num_devices - 1] = saveInfo;
     } else {
-      numMonitored++;
       idx++;
     }
   }
-  idx = numMonitored;
+  unsigned numMonitored = idx;
   list_for_each_entry_safe(device, list_tmp, nonMonitoredGpu, list) {
     assert(idx <= num_devices);
     if (!options->gpu_specific_opts[idx].doNotMonitor) {
       list_move_tail(&device->list, monitoredGpu);
       nvtop_interface_gpu_opts saveInfo = options->gpu_specific_opts[idx];
-      for (unsigned here = idx; idx > numMonitored; --idx) {
-        options->gpu_specific_opts[here] = options->gpu_specific_opts[here - 1];
+      for (unsigned nonMonPred = idx; nonMonPred > numMonitored; --nonMonPred) {
+        options->gpu_specific_opts[nonMonPred] = options->gpu_specific_opts[nonMonPred - 1];
       }
       options->gpu_specific_opts[numMonitored] = saveInfo;
       numMonitored++;

--- a/src/interface_setup_win.c
+++ b/src/interface_setup_win.c
@@ -608,16 +608,19 @@ void handle_setup_win_keypress(int keyId, struct nvtop_interface *interface) {
   if (interface->setup_win.visible) {
     switch (keyId) {
 
+    case 'l':
     case KEY_RIGHT:
       if (interface->setup_win.indentation_level < 2)
         interface->setup_win.indentation_level++;
       break;
 
+    case 'h':
     case KEY_LEFT:
       if (interface->setup_win.indentation_level > 0)
         interface->setup_win.indentation_level--;
       break;
 
+    case 'k':
     case KEY_UP:
       if (interface->setup_win.indentation_level == 0) {
         if (interface->setup_win.selected_section != setup_general_selected) {
@@ -637,6 +640,7 @@ void handle_setup_win_keypress(int keyId, struct nvtop_interface *interface) {
       }
       break;
 
+    case 'j':
     case KEY_DOWN:
       if (interface->setup_win.indentation_level == 0) {
         if (interface->setup_win.selected_section + 1 != setup_window_selection_count) {

--- a/src/nvtop.c
+++ b/src/nvtop.c
@@ -307,9 +307,13 @@ int main(int argc, char **argv) {
     case '-':
       interface_key(input_char, interface);
       break;
+    case 'k':
     case KEY_UP:
+    case 'j':
     case KEY_DOWN:
+    case 'h':
     case KEY_LEFT:
+    case 'l':
     case KEY_RIGHT:
     case KEY_ENTER:
     case '\n':


### PR DESCRIPTION
since line 73 has moved options backward by one space (towards head) when doNotMonitor is true, idx shouldn't increase in such case. 

For example, we have two gpus with [1:doNotMonitor:false, 2:doNotMonitor:true], current code would first check gpu1 and move it to the tail, after that, gpus' options would become [2:doNotMonitor:true, 1:doNotMonitor:false]. Then in next iteration, code will check gpu1 again and gpu2's option is ignored. 