### PR TITLE
fix typo in pci id

### DIFF
--- a/src/amdgpu_ids.h
+++ b/src/amdgpu_ids.h
@@ -499,7 +499,7 @@ static struct amdgpu_id_struct amdgpu_ids[] = {
     {0x98E4, 0xE9, "AMD Radeon R4 Graphics"},
     {0x98E4, 0xEA, "AMD Radeon R4 Graphics"},
     {0x98E4, 0xEB, "AMD Radeon R3 Graphics"},
-    {0x98E4, 0xEB, "AMD Radeon R4 Graphics"},
+    {0x98E4, 0xEC, "AMD Radeon R4 Graphics"},
 };
 
 #endif


### PR DESCRIPTION
@amdsc21 noticed there is a small typo in the PCI ID list.
The same issue in [1], we have asked the maintainer there to fix that also.
[1] https://gitlab.freedesktop.org/mesa/drm/-/blob/main/data/amdgpu.ids