### PR TITLE
Deactivate callback for hidden gpus

### DIFF
--- a/include/nvtop/extract_processinfo_fdinfo.h
+++ b/include/nvtop/extract_processinfo_fdinfo.h
@@ -50,6 +50,14 @@ void processinfo_register_fdinfo_callback(processinfo_fdinfo_callback callback, 
 void processinfo_drop_callback(const struct gpu_info *info);
 
 /**
+ * @brief Enables or disables a fdinfo processing callback
+ *
+ * @param info Enabling/Disabling the callback to this gpu_info
+ * @param enable True to enable the callback, false to disable
+ */
+void processinfo_enable_disable_callback_for(const struct gpu_info *info, bool enable);
+
+/**
  * @brief Scann all the processes in /proc. Call the registered callbacks on
  * each file descriptor to the DRM driver that can successfully be oppened. If a
  * callback succeeds, the gpu_info structure processes array will be updated

--- a/src/extract_gpuinfo_amdgpu_utils.c
+++ b/src/extract_gpuinfo_amdgpu_utils.c
@@ -23,6 +23,8 @@
 
 #include "amdgpu_ids.h"
 
+const char *amdgpu_parse_marketing_name(struct amdgpu_gpu_info *info);
+
 const char * amdgpu_parse_marketing_name(struct amdgpu_gpu_info *info)
 {
     int i;

--- a/src/extract_gpuinfo_msm.c
+++ b/src/extract_gpuinfo_msm.c
@@ -464,7 +464,6 @@ static int gpuinfo_msm_query_param(int gpu, uint32_t param, uint64_t *value) {
 void gpuinfo_msm_populate_static_info(struct gpu_info *_gpu_info) {
   struct gpu_info_msm *gpu_info = container_of(_gpu_info, struct gpu_info_msm, base);
   struct gpuinfo_static_info *static_info = &gpu_info->base.static_info;
-  const char *dev_name;
 
   static_info->integrated_graphics = true;
   RESET_ALL(static_info->valid);
@@ -488,18 +487,18 @@ static const char meminfo_available[] = "MemAvailable";
 
 void gpuinfo_msm_refresh_dynamic_info(struct gpu_info *_gpu_info) {
   struct gpu_info_msm *gpu_info = container_of(_gpu_info, struct gpu_info_msm, base);
-  struct gpuinfo_static_info *static_info = &gpu_info->base.static_info;
+  // struct gpuinfo_static_info *static_info = &gpu_info->base.static_info;
   struct gpuinfo_dynamic_info *dynamic_info = &gpu_info->base.dynamic_info;
 
   RESET_ALL(dynamic_info->valid);
   dynamic_info->encode_decode_shared = true;
 
   // GPU clock
-  uint64_t val;
-  if (gpuinfo_msm_query_param(gpu_info->fd, MSM_PARAM_MAX_FREQ, &val) == 0) {
+  uint64_t clock_val;
+  if (gpuinfo_msm_query_param(gpu_info->fd, MSM_PARAM_MAX_FREQ, &clock_val) == 0) {
     // TODO: No way to query current clock speed.
-    SET_GPUINFO_DYNAMIC(dynamic_info, gpu_clock_speed, val / 1000000);
-    SET_GPUINFO_DYNAMIC(dynamic_info, gpu_clock_speed_max, val / 1000000);
+    SET_GPUINFO_DYNAMIC(dynamic_info, gpu_clock_speed, clock_val / 1000000);
+    SET_GPUINFO_DYNAMIC(dynamic_info, gpu_clock_speed_max, clock_val / 1000000);
   }
 
   // Mem clock

--- a/src/extract_gpuinfo_msm_utils.c
+++ b/src/extract_gpuinfo_msm_utils.c
@@ -89,6 +89,8 @@ static const struct msm_id_struct msm_ids[] = {
   {0x006006030500, "Adreno 7c+ Gen 3 Lite"},
 };
 
+const char * msm_parse_marketing_name(uint64_t gpu_id);
+
 const char * msm_parse_marketing_name(uint64_t gpu_id) {
   for (unsigned i = 0; i < ARRAY_SIZE(msm_ids); i++) {
     if (gpu_id == msm_ids[i].id) {

--- a/src/interface_options.c
+++ b/src/interface_options.c
@@ -21,6 +21,7 @@
 
 #include "nvtop/interface_options.h"
 #include "ini.h"
+#include "nvtop/extract_processinfo_fdinfo.h"
 #include "nvtop/interface_common.h"
 
 #include <assert.h>
@@ -98,6 +99,8 @@ unsigned interface_check_and_fix_monitored_gpus(unsigned num_devices, struct lis
     options->gpu_specific_opts[0].doNotMonitor = false;
     numMonitored++;
   }
+  list_for_each_entry(device, monitoredGpu, list) { processinfo_enable_disable_callback_for(device, true); }
+  list_for_each_entry(device, nonMonitoredGpu, list) { processinfo_enable_disable_callback_for(device, false); }
   return numMonitored;
 }
 


### PR DESCRIPTION
Should fix #222

Disable callbacks for GPUs that are hidden. This will also prevent an fdinfo swipe when all the callbacks are disabled.