### PR TITLE
cmake version upgrade docker script. 3.10 to 3.18

### DIFF
--- a/AppImage/make_appimage_ubuntu_1804_docker.sh
+++ b/AppImage/make_appimage_ubuntu_1804_docker.sh
@@ -2,7 +2,7 @@
 
 install_deps() {
   apt-get update
-  apt-get install -y cmake gcc g++ libncurses5-dev libncursesw5-dev libdrm-dev wget file libudev-dev
+  apt-get install -y gcc g++ libncurses5-dev libncursesw5-dev libdrm-dev wget file libudev-dev
 }
 
 configure_nvtop() {
@@ -23,8 +23,15 @@ get_linuxdeploy() {
   ./linuxdeploy-x86_64.AppImage --appimage-extract
 }
 
+get_cmake() {
+  wget -nc https://github.com/Kitware/CMake/releases/download/v3.18.0/cmake-3.18.0.tar.gz
+  tar zxf cmake-3.18.0.tar.gz
+  ./cmake-3.18.0/bootstrap --prefix=/usr && make && make install
+}
+
 create_AppImage() {
   install_deps
+  get_cmake
   mkdir nvtop_build
   cd nvtop_build
   configure_nvtop

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,12 @@ FROM ${IMAGE} as builder
 ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get update && \
-  apt-get install -yq build-essential cmake libncurses5-dev libncursesw5-dev \
+  apt-get install -yq build-essential wget libncurses5-dev libncursesw5-dev libssl-dev \
   pkg-config libdrm-dev libgtest-dev libudev-dev
+
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.18.0/cmake-3.18.0.tar.gz
+RUN tar zxf cmake-3.18.0.tar.gz
+RUN ./cmake-3.18.0/bootstrap --prefix=/usr && make && make install
 
 COPY . /nvtop
 WORKDIR /nvtop


### PR DESCRIPTION
docker image was not built because of the lower version of cmake.
I made some cmake updating script on the Dockerfile so that the image is now available without any error.
Please check before/after below and approve code so that everyone can use docker image of this awesome nvtop.

Thanks for your great contribution! :)

- before
![image](https://github.com/Syllo/nvtop/assets/89365607/2e9cbf03-576b-49bc-aeb2-8e5f5321ab63)

- after
- build
![image](https://github.com/Syllo/nvtop/assets/89365607/934bf314-da2a-4206-b26e-7df2728d977e)

- running container
![image](https://github.com/Syllo/nvtop/assets/89365607/9fa08434-5554-4ac6-bffe-b4ead128e49d)

