### PR TITLE
interface_options: handle both XDG_CONFIG_HOME and HOME being unset

### DIFF
--- a/src/interface_options.c
+++ b/src/interface_options.c
@@ -353,6 +353,8 @@ static bool create_config_directory_rec(char *config_directory) {
 static const char *boolean_string(bool value) { return value ? "true" : "false"; }
 
 bool save_interface_options_to_config_file(unsigned total_dev_count, const nvtop_interface_option *options) {
+  if (!options->config_file_location)
+    return false;
 
   char folder_path[PATH_MAX];
   strcpy(folder_path, options->config_file_location);

--- a/src/interface_options.c
+++ b/src/interface_options.c
@@ -43,6 +43,8 @@ static const char *default_config_path(void) {
   if (!xdg_config_dir) {
     // XDG config dir not set, default to $HOME/.config
     xdg_config_dir = getenv("HOME");
+    if (!xdg_config_dir)
+            return NULL;
     conf_path_length = sizeof(config_conf_path);
   }
   size_t xdg_path_length = strlen(xdg_config_dir);
@@ -135,12 +137,14 @@ void alloc_interface_options_internals(char *config_location, unsigned num_devic
     strcpy(options->config_file_location, config_location);
   } else {
     const char *default_path = default_config_path();
-    options->config_file_location = malloc(strlen(default_path) + 1);
-    if (!options->config_file_location) {
-      perror("Cannot allocate memory: ");
-      exit(EXIT_FAILURE);
+    if (default_path) {
+      options->config_file_location = malloc(strlen(default_path) + 1);
+      if (!options->config_file_location) {
+	perror("Cannot allocate memory: ");
+	exit(EXIT_FAILURE);
+      }
+      strcpy(options->config_file_location, default_path);
     }
-    strcpy(options->config_file_location, default_path);
   }
 }
 


### PR DESCRIPTION
When HOME was unset, nvtop would segfault as in the following trace:

Process terminating with default action of signal 11 (SIGSEGV)
 Access not within mapped region at address 0x0
   at 0x488B298: strlen (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
   by 0x119F33: default_config_path (interface_options.c:48)
   by 0x11A5F3: alloc_interface_options_internals (interface_options.c:138)
   by 0x10FEBF: main (nvtop.c:209)

We need to handle the unlikely case in which HOME is also unset.  On top of that, default_config_path()'s return value has to be checked in the calling function to make sure a default config file's path string is only allocated when != NULL.