### PR TITLE
MSM: Add support for a750 and ignore speed-bin

### DIFF
--- a/src/extract_gpuinfo_msm.c
+++ b/src/extract_gpuinfo_msm.c
@@ -471,6 +471,11 @@ void gpuinfo_msm_populate_static_info(struct gpu_info *_gpu_info) {
   uint64_t gpuid;
   if (gpuinfo_msm_query_param(gpu_info->fd, MSM_PARAM_CHIP_ID, &gpuid) == 0) {
     const char* name = msm_parse_marketing_name(gpuid);
+    if (!name) {
+      // Try again ignoring speed-bin in the upper bits.
+      name = msm_parse_marketing_name(gpuid & 0x0000ffffffff);
+    }
+
     if (name) {
       strncpy(static_info->device_name, name, sizeof(static_info->device_name));
     }

--- a/src/extract_gpuinfo_msm_utils.c
+++ b/src/extract_gpuinfo_msm_utils.c
@@ -82,11 +82,14 @@ static const struct msm_id_struct msm_ids[] = {
   // Adreno 7xx
   {CHIPID(730),   "Adreno 730"},
   {CHIPID(740),   "Adreno 740"},
+  {CHIPID(750),   "Adreno 750"},
+  {CHIPID(790),   "Adreno 750"},
 
   // Misc
   {0x00be06030500, "Adreno 8c Gen 3"},
   {0x007506030500, "Adreno 7c+ Gen 3"},
   {0x006006030500, "Adreno 7c+ Gen 3 Lite"},
+  {0x000043051401, "Adreno 750"},
 };
 
 const char * msm_parse_marketing_name(uint64_t gpu_id);


### PR DESCRIPTION
Fairly basic. Adds three new IDs for Adreno 750 products and if the full GPUID isn't found on first linear search, mask off the speed-bin bits of the GPUID and try again.