### PR TITLE
Fix icon in appstream

### DIFF
--- a/desktop/nvtop.metainfo.xml.in
+++ b/desktop/nvtop.metainfo.xml.in
@@ -15,7 +15,7 @@
 
     <launchable type="desktop-id">nvtop.desktop</launchable>
 
-    <icon type="stock">nvtop</icon>
+    <icon type="cached">nvtop.svg</icon>
 
     <categories>
         <category>System</category>


### PR DESCRIPTION
When validating the AppStream metadata as part of the Fedora packaging, we noticed it failed without this applied