### PR TITLE
Fix screenshot URLs in appstream

### DIFF
--- a/desktop/nvtop.metainfo.xml.in
+++ b/desktop/nvtop.metainfo.xml.in
@@ -27,11 +27,11 @@
     <screenshots>
         <screenshot type="default">
             <caption>The nvtop interface</caption>
-            <image>https://github.com/Syllo/nvtop/blob/master/screenshot/NVTOP_ex1.png</image>
+            <image>https://raw.githubusercontent.com/Syllo/nvtop/master/screenshot/NVTOP_ex1.png</image>
         </screenshot>
         <screenshot>
             <caption>The nvtop option screen</caption>
-            <image>https://github.com/Syllo/nvtop/blob/master/screenshot/Nvtop-config.png</image>
+            <image>https://raw.githubusercontent.com/Syllo/nvtop/master/screenshot/Nvtop-config.png</image>
         </screenshot>
     </screenshots>
 


### PR DESCRIPTION
The current URLs are not valid, need to use the resolved "raw" URLs