### PR TITLE
Add missing source file dependency for interfaceTests

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,6 +6,7 @@ if (BUILD_TESTING AND GTest_FOUND)
   # Create a library for testing
   add_library(testLib
     ${PROJECT_SOURCE_DIR}/src/interface_layout_selection.c
+    ${PROJECT_SOURCE_DIR}/src/extract_processinfo_fdinfo.c
     ${PROJECT_SOURCE_DIR}/src/interface_options.c
     ${PROJECT_SOURCE_DIR}/src/ini.c
   )


### PR DESCRIPTION
Otherwise, linker will complain about processinfo_enable_disable_callback_for being left undefined.