### PR TITLE
panfrost: replace debugfs profiling knob with sysfs

### DIFF
--- a/src/extract_gpuinfo_mali_common.c
+++ b/src/extract_gpuinfo_mali_common.c
@@ -94,6 +94,10 @@ bool mali_init_drm_funcs(struct drmFuncTable *drmFuncs,
   if (!drmFuncs->drmCommandWriteRead)
     goto init_error_clean_exit;
 
+  drmFuncs->drmGetDeviceFromDevId = dlsym(state->libdrm_handle, "drmGetDeviceFromDevId");
+  if (!drmFuncs->drmGetDeviceFromDevId)
+    goto init_error_clean_exit;
+
   drmFuncs->drmIoctl = dlsym(state->libdrm_handle, "drmIoctl");
   if (!drmFuncs->drmCommandWriteRead)
     goto init_error_clean_exit;

--- a/src/mali_common.h
+++ b/src/mali_common.h
@@ -38,6 +38,7 @@ struct drmFuncTable {
   typeof(drmAuthMagic) *drmAuthMagic;
   typeof(drmDropMaster) *drmDropMaster;
   typeof(drmCommandWriteRead) *drmCommandWriteRead;
+  typeof(drmGetDeviceFromDevId) *drmGetDeviceFromDevId;
   typeof(drmIoctl) *drmIoctl;
 };
 
@@ -52,7 +53,7 @@ struct mali_process_info_cache;
 struct panfrost_driver_data {
   bool original_profiling_state;
   bool profiler_enabled;
-  unsigned int minor;
+  char *sysfs_filename;
 };
 struct panthor_driver_data {
   uint32_t unused;


### PR DESCRIPTION
Kernel commit b12f3ea7c188 ("drm/panfrost: Replace fdinfo's profiling debugfs knob with sysfs") did away with the debugfs knob that lets profilers enable the hardware support for job accounting and fdinfo numbers. It was replaced with a similar interface, but this time around through sysfs.

Reflect this change in nvtop.