### PR TITLE
Make the appimage be able to work with libfuse3

### DIFF
--- a/AppImage/make_appimage.sh
+++ b/AppImage/make_appimage.sh
@@ -23,6 +23,14 @@ get_linuxdeploy() {
   ./linuxdeploy-x86_64.AppImage --appimage-extract
 }
 
+get_appimagetool() {
+	ARCH=x86_64
+	APPIMAGETOOL=$(wget -q https://api.github.com/repos/probonopd/go-appimage/releases -O - | sed 's/"/ /g; s/ /\n/g' | grep -o 'https.*continuous.*tool.*86_64.*mage$')
+	wget -q "$APPIMAGETOOL" -O ./appimagetool
+	chmod u+x ./appimagetool
+	./appimagetool --appimage-extract
+}
+
 get_cmake() {
   python3 -m venv .venv
   source .venv/bin/activate
@@ -37,7 +45,10 @@ create_AppImage() {
   build_nvtop
   install_nvtop_AppDir
   get_linuxdeploy
-  ./squashfs-root/AppRun --appdir AppDir --output appimage --exclude-library="*udev*" --desktop-file AppDir/usr/share/applications/nvtop.desktop --icon-file AppDir/usr/share/icons/nvtop.svg
+  ./squashfs-root/AppRun --appdir AppDir --exclude-library="*udev*" --desktop-file AppDir/usr/share/applications/nvtop.desktop --icon-file AppDir/usr/share/icons/nvtop.svg
+  rm -rf ./squashfs-root
+  get_appimagetool
+  VERSION=$(./AppDir/AppRun --version | awk '{print $NF}') ./squashfs-root/AppRun -s AppDir
 }
 
 create_AppImage


### PR DESCRIPTION
It uses this version of appimagetool instead because the built in one of linuxdeploy still depends on fuse2: https://github.com/probonopd/go-appimage

Note that I went and also did the --appimage-extract for the appimagetool like you were doing it with linuxdeploy, I don't think it is needed anymore because that appimagetool itself also works with fuse3, but I didn't test the script with podman so I can't be 100% sure. 

One potential breaking change is that the appimage will have a different name, because this version of appimagetool requires one to provide the version of the app to add it to the title of the resulting AppImage.





