### PR TITLE
Add Support for the Intel Xe driver & HWMON power values

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -91,7 +91,7 @@ endif()
 
 option(NVIDIA_SUPPORT "Build support for NVIDIA GPUs through libnvml" ${NVIDIA_SUPPORT_DEFAULT})
 option(AMDGPU_SUPPORT "Build support for AMD GPUs through amdgpu driver" ${AMDGPU_SUPPORT_DEFAULT})
-option(INTEL_SUPPORT "Build support for Intel GPUs through i915 driver" ${INTEL_SUPPORT_DEFAULT})
+option(INTEL_SUPPORT "Build support for Intel GPUs through i915 or xe driver" ${INTEL_SUPPORT_DEFAULT})
 option(MSM_SUPPORT "Build support for Adreno GPUs through msm driver" ${MSM_SUPPORT_DEFAULT})
 option(APPLE_SUPPORT "Build support for Apple GPUs through Metal" ${APPLE_SUPPORT_DEFAULT})
 option(PANFROST_SUPPORT "Build support for Mali GPUs through panfrost driver" ${PANFROST_SUPPORT_DEFAULT})

--- a/README.markdown
+++ b/README.markdown
@@ -9,7 +9,7 @@ accelerators. It can handle multiple GPUs and print information about them in a
 htop-familiar way.
 
 Currently supported vendors are AMD (Linux amdgpu driver), Apple (limited M1 &
-M2 support), Huawei (Ascend), Intel (Linux i915 driver), NVIDIA (Linux
+M2 support), Huawei (Ascend), Intel (Linux i915 or Xe driver), NVIDIA (Linux
 proprietary divers), Qualcomm Adreno (Linux MSM driver).
 
 Because a picture is worth a thousand words:
@@ -88,7 +88,7 @@ use a recent-enough kernel for your GPU.
 
 ### Intel
 
-NVTOP supports Intel GPUs using the `i915` linux driver.
+NVTOP supports Intel GPUs using the `i915` or `xe` linux driver.
 
 Intel introduced the fdinfo interface in kernel 5.19 ([browse kernel
 source](https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/tree/drivers/gpu/drm/i915/i915_drm_client.c?h=linux-5.19.y)).

--- a/src/extract_gpuinfo_intel.c
+++ b/src/extract_gpuinfo_intel.c
@@ -400,7 +400,7 @@ void gpuinfo_intel_refresh_dynamic_info(struct gpu_info *_gpu_info) {
 
   if (!static_info->integrated_graphics) {
     nvtop_pcie_link curr_link_characteristics;
-    int ret = nvtop_device_current_pcie_link(card_dev_noncached, &curr_link_characteristics);
+    int ret = nvtop_device_current_pcie_link(driver_dev_noncached, &curr_link_characteristics);
     if (ret >= 0) {
       SET_GPUINFO_DYNAMIC(dynamic_info, pcie_link_width, curr_link_characteristics.width);
       unsigned pcieGen = nvtop_pcie_gen_from_link_speed(curr_link_characteristics.speed);


### PR DESCRIPTION
Hi, this PR adds basic support for Intel's new Xe driver, it doesn't support GPU utilisation (the fdinfo is different) but all other features that were working for i915 now work for Xe (on an A770).

The added power fields from the HWMON patch were also implemented, but only `power1_max` is present on both i915 and Xe. Temperature, fans, etc. were never implemented by Intel in the HWMON patch.

Also, the memory clock speed attributes (`mem_cur_freq_mhz` & `mem_max_freq_mhz`) don't seem to exist (in either drivers), should they be removed?

Thanks,
Steve