### PR TITLE
docs: Add conda-forge feedstock to install instructions

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -39,6 +39,7 @@ Table of Contents
   - [Arch Linux](#arch-linux)
   - [AppImage](#appimage)
   - [Snap](#snap)
+  - [Conda-forge](#conda-forge)
   - [Docker](#docker)
 - [NVTOP Build](#nvtop-build)
 - [Troubleshoot](#troubleshoot)
@@ -299,6 +300,22 @@ If you are curious how that works, please visit the [AppImage website](https://a
   ```
 
 Notice: The connect commands allow
+
+### Conda-forge
+
+A [conda-forge feedstock for `nvtop`](https://github.com/conda-forge/nvtop-feedstock) is available.
+
+#### conda / mamba / miniforge
+
+```bash
+conda install --channel conda-forge nvtop
+```
+
+#### pixi
+
+```bash
+pixi global install nvtop
+```
 
 ### Docker
 


### PR DESCRIPTION
Following my excitement of realizing that there already was a conda-forge feedstock (https://github.com/conda-forge/nvtop-feedstock) in https://github.com/Syllo/nvtop/issues/76#issuecomment-2274480524, this PR notes the existence of the conda-forge feedstock in the README and adds install instructions for the `conda` family of package managers as well as for `pixi`.