### PR TITLE
Make appimage be able to work on any linux system (and some refactor of the script).

### DIFF
--- a/AppImage/README.md
+++ b/AppImage/README.md
@@ -2,7 +2,7 @@
 
 ```bash
 podman pull ubuntu:18.04
-podman run --interactive --tty --rm --volume $PWD:/nvtop ubuntu:18.04
+podman run --interactive --tty --rm --volume $PWD:/nvtop ubuntu:24.04
 cd nvtop
 ./AppImage/make_appimage.sh
 ```


### PR DESCRIPTION
These changes make the appimage be able to work on any linux system, be it 15 years old or even musl distros. this is done by bundling all the libraries the nvtop binary needs + the ld-linux.so. 

These changes are similar what the deploy everything mode of [go-appimage](https://github.com/probonopd/go-appimage/blob/master/src/appimagetool/README.md) does but I find it far easier to do it manually instead of fighting with the go-appimage parameters though. 

Tested on Artix, Alpine (musl) and Ubuntu 20.04 (old Glibc). 

The only downside is that this makes the appimage 2.4 MiB.

Also updated the readme to use 24.04 instead of 18.04, because with older versions you had to do stuff like using pip to install a newer cmake, none of this is needed anymore by building the appimage this way. 

Edit: I'm linking an artifact if you want to test it, remove the `.txt` from the end. 

[nvtop-3.1.0-x86_64.AppImage.txt](https://github.com/user-attachments/files/17599358/nvtop-3.1.0-x86_64.AppImage.txt)
