### PR TITLE
Intel additional HWMON (Fan + Temp) & i915 process memory usage

### DIFF
--- a/include/nvtop/extract_gpuinfo_common.h
+++ b/include/nvtop/extract_gpuinfo_common.h
@@ -100,6 +100,7 @@ enum gpuinfo_dynamic_info_valid {
   gpuinfo_pcie_rx_valid,
   gpuinfo_pcie_tx_valid,
   gpuinfo_fan_speed_valid,
+  gpuinfo_fan_rpm_valid,
   gpuinfo_gpu_temp_valid,
   gpuinfo_power_draw_valid,
   gpuinfo_power_draw_max_valid,
@@ -124,6 +125,7 @@ struct gpuinfo_dynamic_info {
   unsigned int pcie_rx;             // PCIe throughput in KB/s
   unsigned int pcie_tx;             // PCIe throughput in KB/s
   unsigned int fan_speed;           // Fan speed percentage
+  unsigned int fan_rpm;             // Fan speed RPM
   unsigned int gpu_temp;            // GPU temperature °celsius
   unsigned int power_draw;          // Power usage in milliwatts
   unsigned int power_draw_max;      // Max power usage in milliwatts

--- a/src/extract_gpuinfo_intel.c
+++ b/src/extract_gpuinfo_intel.c
@@ -427,6 +427,11 @@ void gpuinfo_intel_refresh_dynamic_info(struct gpu_info *_gpu_info) {
       unsigned val = strtoul(hwmon_fan, NULL, 10);
       SET_GPUINFO_DYNAMIC(dynamic_info, fan_speed, val / maxFanValue);
     }
+    const char *hwmon_temp;
+    if (nvtop_device_get_sysattr_value(hwmon_dev_noncached, "temp1_input", &hwmon_temp) >= 0) {
+      unsigned val = strtoul(hwmon_temp, NULL, 10);
+      SET_GPUINFO_DYNAMIC(dynamic_info, gpu_temp, val / 1000);
+    }
   }
 
   // Let the temporary devices be garbage collected

--- a/src/extract_gpuinfo_intel.c
+++ b/src/extract_gpuinfo_intel.c
@@ -72,7 +72,7 @@ struct gpu_info_intel {
 
   struct {
     unsigned energy_uj;
-    struct timespec time;
+    nvtop_time time;
   } energy;
 };
 
@@ -428,15 +428,20 @@ void gpuinfo_intel_refresh_dynamic_info(struct gpu_info *_gpu_info) {
       unsigned val = strtoul(hwmon_temp, NULL, 10);
       SET_GPUINFO_DYNAMIC(dynamic_info, gpu_temp, val / 1000);
     }
+
     const char *hwmon_power_max;
-    if (nvtop_device_get_sysattr_value(hwmon_dev_noncached, "power1_max", &hwmon_power_max) >= 0) {
+    // power1 is for i915, power2 is for xe
+    if (nvtop_device_get_sysattr_value(hwmon_dev_noncached, "power1_max", &hwmon_power_max) >= 0 ||
+        nvtop_device_get_sysattr_value(hwmon_dev_noncached, "power2_max", &hwmon_power_max) >= 0) {
       unsigned val = strtoul(hwmon_power_max, NULL, 10);
       SET_GPUINFO_DYNAMIC(dynamic_info, power_draw_max, val / 1000);
     }
 
     const char *hwmon_energy;
-    if (nvtop_device_get_sysattr_value(hwmon_dev_noncached, "energy1_input", &hwmon_energy) >= 0) {
-      struct timespec ts, ts_diff;
+    // energy1 is for i915, energy2 is for xe
+    if (nvtop_device_get_sysattr_value(hwmon_dev_noncached, "energy1_input", &hwmon_energy) >= 0 ||
+        nvtop_device_get_sysattr_value(hwmon_dev_noncached, "energy2_input", &hwmon_energy) >= 0) {
+      nvtop_time ts, ts_diff;
       nvtop_get_current_time(&ts);
       unsigned val = strtoul(hwmon_energy, NULL, 10);
       unsigned old = gpu_info->energy.energy_uj;

--- a/src/extract_gpuinfo_intel.c
+++ b/src/extract_gpuinfo_intel.c
@@ -418,10 +418,9 @@ void gpuinfo_intel_refresh_dynamic_info(struct gpu_info *_gpu_info) {
   if (hwmon_dev_noncached) {
     const char *hwmon_fan;
     // maxFanValue is just a guess, there is no way to get the max fan speed from hwmon
-    const unsigned maxFanValue = 4000/100;
     if (nvtop_device_get_sysattr_value(hwmon_dev_noncached, "fan1_input", &hwmon_fan) >= 0) {
       unsigned val = strtoul(hwmon_fan, NULL, 10);
-      SET_GPUINFO_DYNAMIC(dynamic_info, fan_speed, val / maxFanValue);
+      SET_GPUINFO_DYNAMIC(dynamic_info, fan_rpm, val);
     }
     const char *hwmon_temp;
     if (nvtop_device_get_sysattr_value(hwmon_dev_noncached, "temp1_input", &hwmon_temp) >= 0) {

--- a/src/extract_gpuinfo_intel.c
+++ b/src/extract_gpuinfo_intel.c
@@ -119,6 +119,7 @@ static const char i915_drm_intel_render[] = "drm-engine-render";
 static const char i915_drm_intel_copy[] = "drm-engine-copy";
 static const char i915_drm_intel_video[] = "drm-engine-video";
 static const char i915_drm_intel_video_enhance[] = "drm-engine-video-enhance";
+static const char i915_drm_intel_vram[] = "drm-total-local0";
 
 static const char xe_drm_intel_vram[] = "drm-total-vram0";
 
@@ -159,7 +160,7 @@ static bool parse_drm_fdinfo_intel(struct gpu_info *info, FILE *fdinfo_file, str
       bool is_video = !strcmp(key, i915_drm_intel_video);
       bool is_video_enhance = !strcmp(key, i915_drm_intel_video_enhance);
       
-      if (strcmp(key, xe_drm_intel_vram)) {
+      if (!strcmp(key, i915_drm_intel_vram) || !strcmp(key, xe_drm_intel_vram)) {
         // TODO: do we count "gtt mem" too?
         unsigned long mem_int;
         char *endptr;

--- a/src/extract_gpuinfo_intel.c
+++ b/src/extract_gpuinfo_intel.c
@@ -420,6 +420,13 @@ void gpuinfo_intel_refresh_dynamic_info(struct gpu_info *_gpu_info) {
       unsigned val = strtoul(hwmon_power_max, NULL, 10);
       SET_GPUINFO_DYNAMIC(dynamic_info, power_draw_max, val / 1000);
     }
+    const char *hwmon_fan;
+    // maxFanValue is just a guess, there is no way to get the max fan speed from hwmon
+    const unsigned maxFanValue = 4000/100;
+    if (nvtop_device_get_sysattr_value(hwmon_dev_noncached, "fan1_input", &hwmon_fan) >= 0) {
+      unsigned val = strtoul(hwmon_fan, NULL, 10);
+      SET_GPUINFO_DYNAMIC(dynamic_info, fan_speed, val / maxFanValue);
+    }
   }
 
   // Let the temporary devices be garbage collected

--- a/src/info_messages_linux.c
+++ b/src/info_messages_linux.c
@@ -37,10 +37,15 @@ static int get_linux_kernel_release(unsigned *major, unsigned *minor, unsigned *
   return nmatch != 3;
 }
 
-static char *allMessages[] = {
+enum messages {
+  AMD_GPU_514,
+  INTEL_GPU_519,
+  MSM_GPU,
+};
+
+static const char *allMessages[] = {
     "Nvtop won't be able to show AMD GPU processes on your kernel version (requires Linux >= 5.14)",
     "Nvtop won't be able to show Intel GPU utilization and processes on your kernel version (requires Linux >= 5.19)",
-    "This version of Nvtop does not yet support reporting all data for Intel GPUs, such as memory, power, fan and temperature information",
     "This version of Nvtop does not yet support reporting all data for MSM GPUs, such as power, fan and temperature information",
 };
 static const char *message_array[sizeof(allMessages) / sizeof(*allMessages)];
@@ -69,16 +74,15 @@ void get_info_messages(struct list_head *devices, unsigned *num_messages, const 
   }
   if (hasAMD) {
     if (linux_major < 5 || (linux_major == 5 && linux_minor < 14)) {
-      message_array[(*num_messages)++] = allMessages[0];
+      message_array[(*num_messages)++] = allMessages[AMD_GPU_514];
     }
   }
   if (hasIntel) {
     if (linux_major < 5 || (linux_major == 5 && linux_minor < 19)) {
-      message_array[(*num_messages)++] = allMessages[1];
+      message_array[(*num_messages)++] = allMessages[INTEL_GPU_519];
     }
-    message_array[(*num_messages)++] = allMessages[2];
   }
   if (hasMSM) {
-    message_array[(*num_messages)++] = allMessages[3];
+    message_array[(*num_messages)++] = allMessages[MSM_GPU];
   }
 }

--- a/src/nvtop.c
+++ b/src/nvtop.c
@@ -236,8 +236,7 @@ int main(int argc, char **argv) {
       allDevicesOptions.gpu_specific_opts[i].to_draw = 0;
     }
   }
-  if (hide_processes_option)
-    allDevicesOptions.hide_processes_list = true;
+  allDevicesOptions.hide_processes_list = hide_processes_option;
   if (encode_decode_timer_option_set) {
     allDevicesOptions.encode_decode_hiding_timer = encode_decode_hide_time;
     if (allDevicesOptions.encode_decode_hiding_timer < 0.)


### PR DESCRIPTION
Hi,

i915 has recently added fan speeds in kernel 6.12, this PR implements that ([patch](https://patchwork.freedesktop.org/patch/610458/)). There's also a temperature patch being developed upstream that I've also implemented support for ([patch series](https://patchwork.freedesktop.org/series/137874/)).

I don't know if it was always like this or recently implemented, but i915 also has `drm-total-local0` in the fdinfo, which is the GPU's memory used by that process. I also fixed a logic error that resulted in Xe reading the wrong value as memory usage.

The energy consumption was exposed by i915 in joules, I've now converted that into watts for nvtop to display.

Here's an example of my GPU:

![nvtop example UI for an A770](https://github.com/user-attachments/assets/5e0a159b-c4e3-4d0a-9e85-880d574b9ac5)


Also it seemed like `hide_processes_list` was left uninitialized instead of false, causing it to randomly enable in my builds, which is also fixed.

I'm also working on using the drm ioctls to get the memory usage for i915, in my [intel-ioctl branch](https://github.com/Steve-Tech/nvtop/tree/intel-ioctl), but I'm omitted it from this PR since I didn't want to make it too big to review.

Thanks,
Steve