### PR TITLE
fix build with gcc 15

### DIFF
--- a/include/nvtop/interface.h
+++ b/include/nvtop/interface.h
@@ -26,6 +26,8 @@
 #include "nvtop/interface_common.h"
 #include "nvtop/interface_options.h"
 
+#include <ncurses.h>
+
 struct nvtop_interface;
 
 struct nvtop_interface *initialize_curses(unsigned total_devices, unsigned num_devices, unsigned largest_device_name,
@@ -47,12 +49,12 @@ void update_window_size_to_terminal_size(struct nvtop_interface *inter);
 
 void interface_key(int keyId, struct nvtop_interface *inter);
 
-bool is_escape_for_quit(struct nvtop_interface *inter);
+NCURSES_BOOL is_escape_for_quit(struct nvtop_interface *inter);
 
-bool interface_freeze_processes(struct nvtop_interface *interface);
+NCURSES_BOOL interface_freeze_processes(struct nvtop_interface *interface);
 
 int interface_update_interval(const struct nvtop_interface *interface);
 
-bool show_information_messages(unsigned num_messages, const char **messages);
+NCURSES_BOOL show_information_messages(unsigned num_messages, const char **messages);
 
 #endif // INTERFACE_H_

--- a/include/nvtop/interface_layout_selection.h
+++ b/include/nvtop/interface_layout_selection.h
@@ -5,6 +5,7 @@
 #include "nvtop/interface_options.h"
 
 #include <stdbool.h>
+#include <ncurses.h>
 
 struct window_position {
   unsigned posX, posY, sizeX, sizeY;
@@ -19,6 +20,6 @@ void compute_sizes_from_layout(unsigned monitored_dev_count, unsigned device_hea
                                struct window_position *device_positions, unsigned *num_plots,
                                struct window_position plot_positions[MAX_CHARTS], unsigned *map_device_to_plot,
                                struct window_position *process_position, struct window_position *setup_position,
-                               bool process_win_hide);
+                               NCURSES_BOOL process_win_hide);
 
 #endif // INTERFACE_LAYOUT_SELECTION_H__


### PR DESCRIPTION
Fixes definition of bool to be consistent between code and headers.

```
../src/interface.c:1799:6: error: conflicting types for 'is_escape_for_quit'; have 'NCURSES_BOOL(struct nvtop_interface *)' {aka 'int(struct nvtop_interface *)'}
 1799 | bool is_escape_for_quit(struct nvtop_interface *interface) {
      |      ^~~~~~~~~~~~~~~~~~
In file included from ../src/interface.c:22:
../include/nvtop/interface.h:50:6: note: previous declaration of 'is_escape_for_quit' with type '_Bool(struct nvtop_interface *)'
   50 | bool is_escape_for_quit(struct nvtop_interface *inter);
      |      ^~~~~~~~~~~~~~~~~~
../src/interface.c:1929:6: error: conflicting types for 'interface_freeze_processes'; have 'NCURSES_BOOL(struct nvtop_interface *)' {aka 'int(struct nvtop_interface *)'}
 1929 | bool interface_freeze_processes(struct nvtop_interface *interface) {
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~
../include/nvtop/interface.h:52:6: note: previous declaration of 'interface_freeze_processes' with type '_Bool(struct nvtop_interface *)'
   52 | bool interface_freeze_processes(struct nvtop_interface *interface);
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~~
../src/interface.c:1971:6: error: conflicting types for 'show_information_messages'; have 'NCURSES_BOOL(unsigned int,  const char **)' {aka 'int(unsigned int,  const char **)'}
 1971 | bool show_information_messages(unsigned num_messages, const char **messages) {
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~
../include/nvtop/interface.h:56:6: note: previous declaration of 'show_information_messages' with type '_Bool(unsigned int,  const char **)'
   56 | bool show_information_messages(unsigned num_messages, const char **messages);
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~

../src/interface_layout_selection.c:233:6: error: conflicting types for 'compute_sizes_from_layout'; have 'void(unsigned int,  unsigned int,  unsigned int,  unsigned int,  unsigned int,  const nvtop_interface_gpu_opts *, process_field_displayed,  struct window_position *, unsigned int *, struct window_position *, unsigned int *, struct window_position *, struct window_position *, NCURSES_BOOL)' {aka 'void(unsigned int,  unsigned int,  unsigned int,  unsigned int,  unsigned int,  const nvtop_interface_gpu_opts *, int,  struct window_position *, unsigned int *, struct window_position *, unsigned int *, struct window_position *, struct window_position *, int)'}
  233 | void compute_sizes_from_layout(unsigned devices_count, unsigned device_header_rows, unsigned device_header_cols,
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~
In file included from ../src/interface_layout_selection.c:1:
../include/nvtop/interface_layout_selection.h:16:6: note: previous declaration of 'compute_sizes_from_layout' with type 'void(unsigned int,  unsigned int,  unsigned int,  unsigned int,  unsigned int,  const nvtop_interface_gpu_opts *, process_field_displayed,  struct window_position *, unsigned int *, struct window_position *, unsigned int *, struct window_position *, struct window_position *, _Bool)' {aka 'void(unsigned int,  unsigned int,  unsigned int,  unsigned int,  unsigned int,  const nvtop_interface_gpu_opts *, int,  struct window_position *, unsigned int *, struct window_position *, unsigned int *, struct window_position *, struct window_position *, _Bool)'}
   16 | void compute_sizes_from_layout(unsigned monitored_dev_count, unsigned device_header_rows, unsigned device_header_cols,
      |      ^~~~~~~~~~~~~~~~~~~~~~~~~
```