### PR TITLE
Workaround broken PCIe speeds on Intel Arc

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -74,26 +74,27 @@ if(AMDGPU_SUPPORT OR INTEL_SUPPORT OR V3D_SUPPORT)
   target_sources(nvtop PRIVATE device_discovery_linux.c)
 endif()
 
-if(AMDGPU_SUPPORT OR MSM_SUPPORT OR PANFROST_SUPPORT OR PANTHOR_SUPPORT)
+if(AMDGPU_SUPPORT OR INTEL_SUPPORT OR MSM_SUPPORT OR PANFROST_SUPPORT OR PANTHOR_SUPPORT)
   # Search for libdrm for AMDGPU support
   find_package(Libdrm)
 
   if(Libdrm_FOUND)
     message(STATUS "Found libdrm; Enabling support")
     target_include_directories(nvtop PRIVATE ${Libdrm_INCLUDE_DIRS})
-    if (AMDGPU_SUPPORT)
-      target_sources(nvtop PRIVATE extract_gpuinfo_amdgpu.c)
-      target_sources(nvtop PRIVATE extract_gpuinfo_amdgpu_utils.c)
-    endif()
-
-    if (MSM_SUPPORT)
-      target_sources(nvtop PRIVATE extract_gpuinfo_msm.c)
-      target_sources(nvtop PRIVATE extract_gpuinfo_msm_utils.c)
-    endif()
-
   else()
-    message(FATAL_ERROR "libdrm not found; This library is required for AMDGPU and MSM support")
+    message(FATAL_ERROR "libdrm not found; This library is required for AMDGPU, INTEL, MSM, PANFROST and PANTHOR support")
+    # CMake will exit if libdrm is not found
   endif()
+endif()
+
+if (AMDGPU_SUPPORT)
+  target_sources(nvtop PRIVATE extract_gpuinfo_amdgpu.c)
+  target_sources(nvtop PRIVATE extract_gpuinfo_amdgpu_utils.c)
+endif()
+
+if (MSM_SUPPORT)
+  target_sources(nvtop PRIVATE extract_gpuinfo_msm.c)
+  target_sources(nvtop PRIVATE extract_gpuinfo_msm_utils.c)
 endif()
 
 if(INTEL_SUPPORT)

--- a/src/extract_gpuinfo_intel.c
+++ b/src/extract_gpuinfo_intel.c
@@ -71,7 +71,7 @@ void gpuinfo_intel_shutdown(void) {
   for (unsigned i = 0; i < intel_gpu_count; ++i) {
     struct gpu_info_intel *current = &gpu_infos[i];
     if (current->card_fd)
-        close(current->card_fd);
+      close(current->card_fd);
     nvtop_device_unref(current->card_device);
     nvtop_device_unref(current->driver_device);
   }
@@ -248,9 +248,6 @@ void gpuinfo_intel_refresh_dynamic_info(struct gpu_info *_gpu_info) {
     SET_GPUINFO_DYNAMIC(dynamic_info, gpu_clock_speed_max, val);
   }
 
-  // TODO: find how to extract global utilization
-  // gpu util will be computed as the sum of all the processes utilization for now
-
   if (!static_info->integrated_graphics) {
     nvtop_pcie_link curr_link_characteristics;
     int ret = nvtop_device_current_pcie_link(bridge_dev_noncached, &curr_link_characteristics);
@@ -261,7 +258,6 @@ void gpuinfo_intel_refresh_dynamic_info(struct gpu_info *_gpu_info) {
     }
   }
 
-  // TODO: Attributes such as memory, fan, temperature, power info should be available once the hwmon patch lands
   if (hwmon_dev_noncached) {
     const char *hwmon_fan;
     // maxFanValue is just a guess, there is no way to get the max fan speed from hwmon

--- a/src/extract_gpuinfo_intel.c
+++ b/src/extract_gpuinfo_intel.c
@@ -271,19 +271,20 @@ void gpuinfo_intel_refresh_dynamic_info(struct gpu_info *_gpu_info) {
 
   if (hwmon_dev_noncached) {
     const char *hwmon_fan;
-    // maxFanValue is just a guess, there is no way to get the max fan speed from hwmon
     if (nvtop_device_get_sysattr_value(hwmon_dev_noncached, "fan1_input", &hwmon_fan) >= 0) {
       unsigned val = strtoul(hwmon_fan, NULL, 10);
       SET_GPUINFO_DYNAMIC(dynamic_info, fan_rpm, val);
     }
     const char *hwmon_temp;
-    if (nvtop_device_get_sysattr_value(hwmon_dev_noncached, "temp1_input", &hwmon_temp) >= 0) {
+    // temp1 is for i915, power2 is for `pkg` on xe
+    if (nvtop_device_get_sysattr_value(hwmon_dev_noncached, "temp1_input", &hwmon_temp) >= 0 ||
+        nvtop_device_get_sysattr_value(hwmon_dev_noncached, "temp2_input", &hwmon_temp) >= 0) {
       unsigned val = strtoul(hwmon_temp, NULL, 10);
       SET_GPUINFO_DYNAMIC(dynamic_info, gpu_temp, val / 1000);
     }
 
     const char *hwmon_power_max;
-    // power1 is for i915, power2 is for xe
+    // power1 is for i915 and `card` on supported cards on xe, power2 is `pkg` on xe
     if (nvtop_device_get_sysattr_value(hwmon_dev_noncached, "power1_max", &hwmon_power_max) >= 0 ||
         nvtop_device_get_sysattr_value(hwmon_dev_noncached, "power2_max", &hwmon_power_max) >= 0) {
       unsigned val = strtoul(hwmon_power_max, NULL, 10);
@@ -291,7 +292,7 @@ void gpuinfo_intel_refresh_dynamic_info(struct gpu_info *_gpu_info) {
     }
 
     const char *hwmon_energy;
-    // energy1 is for i915, energy2 is for xe
+    // energy1 is for i915 and `card` on supported cards on xe, energy2 is `pkg` on xe
     if (nvtop_device_get_sysattr_value(hwmon_dev_noncached, "energy1_input", &hwmon_energy) >= 0 ||
         nvtop_device_get_sysattr_value(hwmon_dev_noncached, "energy2_input", &hwmon_energy) >= 0) {
       nvtop_time ts;

--- a/src/extract_gpuinfo_intel.c
+++ b/src/extract_gpuinfo_intel.c
@@ -87,6 +87,7 @@ static bool parse_drm_fdinfo_intel(struct gpu_info *info, FILE *fdinfo_file, str
   case DRIVER_XE:
     return parse_drm_fdinfo_intel_xe(info, fdinfo_file, process_info);
   }
+  return false;
 }
 
 static void add_intel_cards(struct nvtop_device *dev, struct list_head *devices, unsigned *count) {

--- a/src/extract_gpuinfo_intel.c
+++ b/src/extract_gpuinfo_intel.c
@@ -294,7 +294,7 @@ void gpuinfo_intel_refresh_dynamic_info(struct gpu_info *_gpu_info) {
     // energy1 is for i915, energy2 is for xe
     if (nvtop_device_get_sysattr_value(hwmon_dev_noncached, "energy1_input", &hwmon_energy) >= 0 ||
         nvtop_device_get_sysattr_value(hwmon_dev_noncached, "energy2_input", &hwmon_energy) >= 0) {
-      nvtop_time ts, ts_diff;
+      nvtop_time ts;
       nvtop_get_current_time(&ts);
       unsigned val = strtoul(hwmon_energy, NULL, 10);
       unsigned old = gpu_info->energy.energy_uj;

--- a/src/extract_gpuinfo_intel.h
+++ b/src/extract_gpuinfo_intel.h
@@ -61,6 +61,8 @@ struct gpu_info_intel {
   struct nvtop_device *hwmon_device;
   struct intel_process_info_cache *last_update_process_cache, *current_update_process_cache; // Cached processes info
 
+  struct nvtop_device *bridge_device;
+
   struct {
     unsigned energy_uj;
     struct timespec time;

--- a/src/extract_gpuinfo_intel_i915.c
+++ b/src/extract_gpuinfo_intel_i915.c
@@ -255,6 +255,8 @@ bool parse_drm_fdinfo_intel_i915(struct gpu_info *info, FILE *fdinfo_file, struc
   struct intel_process_info_cache *cache_entry;
   struct unique_cache_id ucid = {.client_id = cid, .pid = process_info->pid, .pdev = gpu_info->base.pdev};
   HASH_FIND_CLIENT(gpu_info->last_update_process_cache, &ucid, cache_entry);
+  // TODO: find how to extract global utilization
+  // gpu util will be computed as the sum of all the processes utilization for now
   if (cache_entry) {
     uint64_t time_elapsed = nvtop_difftime_u64(cache_entry->last_measurement_tstamp, current_time);
     HASH_DEL(gpu_info->last_update_process_cache, cache_entry);

--- a/src/extract_gpuinfo_intel_xe.c
+++ b/src/extract_gpuinfo_intel_xe.c
@@ -79,7 +79,7 @@ void gpuinfo_intel_xe_refresh_dynamic_info(struct gpu_info *_gpu_info) {
   struct gpuinfo_dynamic_info *dynamic_info = &gpu_info->base.dynamic_info;
 
   if (gpu_info->card_fd) {
-    int32_t length = 0;
+    uint32_t length = 0;
     struct drm_xe_query_mem_regions *regions =
         xe_device_query_alloc_fetch(gpu_info->card_fd, DRM_XE_DEVICE_QUERY_MEM_REGIONS, &length);
     if (regions) {
@@ -103,7 +103,7 @@ void gpuinfo_intel_xe_refresh_dynamic_info(struct gpu_info *_gpu_info) {
 }
 
 static const char xe_drm_intel_vram[] = "drm-total-vram0";
-static const char xe_drm_intel_gtt[] = "drm-total-gtt";
+// static const char xe_drm_intel_gtt[] = "drm-total-gtt";
 // Render
 static const char xe_drm_intel_cycles_rcs[] = "drm-cycles-rcs";
 static const char xe_drm_intel_total_cycles_rcs[] = "drm-total-cycles-rcs";

--- a/src/extract_gpuinfo_intel_xe.c
+++ b/src/extract_gpuinfo_intel_xe.c
@@ -222,6 +222,8 @@ bool parse_drm_fdinfo_intel_xe(struct gpu_info *info, FILE *fdinfo_file, struct 
   if (cache_entry) {
     HASH_DEL(gpu_info->last_update_process_cache, cache_entry);
 
+    // TODO: find how to extract global utilization
+    // gpu util will be computed as the sum of all the processes utilization for now
     {
       uint64_t cycles_delta = gpu_cycles.rcs - cache_entry->gpu_cycles.rcs;
       uint64_t total_cycles_delta = total_cycles.rcs - cache_entry->total_cycles.rcs;


### PR DESCRIPTION
Hi again,

Intel Arc Alchemist has a weird (hardware?) bug, where the card and one of it's two PCIe bridges report their link speed as PCIe 1.0 x1, this PR implements a workaround to get the correct speed from it's first PCIe bridge.

e.g. `lspci -tv`:
```
-[0000:00]-+-01.1-[01-04]----00.0-[02-04]--+-01.0-[03]----00.0  Intel Corporation DG2 [Arc A770]
                                           \-04.0-[04]----00.0  Intel Corporation DG2 Audio Controller
             ^ Correct       ^ Incorrect     ^ Incorrect
```

I have checked a few probes on the [Linux Hardware Database](https://linux-hardware.org/) to verify whether it's just my system or card, and it's not. There is also a [bug report](https://community.intel.com/t5/Graphics/Intel-Arc-A770-PCIe-Speed-2-5GT-s-Width-x1/m-p/1455448) on Intel's website with some info.

I have no idea if this is fixed in Battlemage.

I've also added Intel to the libdrm detection in `src/CMakeLists.txt`, and moved AMDGPU and MSM support checks out of the libdrm detection block since `FATAL_ERROR` will cause CMake will exit anyway. I hope this is okay.

Thanks,
Steve