### PR TITLE
Add GitHub Workflow to test for successful compilation

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,4 +1,4 @@
-name: Compile
+name: Compile Ubuntu
 
 on:
   - push
@@ -16,6 +16,7 @@ jobs:
 
     env:
       BUILD_DIR: build
+      DEBIAN_FRONTEND: noninteractive
 
     steps:
     - uses: actions/checkout@v4
@@ -28,9 +29,12 @@ jobs:
 
     - name: Build
       run: cmake --build $BUILD_DIR
+
+    - name: Install
+      run: DESTDIR="$PWD/build/install" cmake --build $BUILD_DIR --target install
       
     - name: Upload
       uses: actions/upload-artifact@v4
       with:
         name: nvtop ${{ matrix.os }}
-        path: ${{ env.BUILD_DIR }}/src/nvtop
+        path: ${{ env.BUILD_DIR }}/install

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,0 +1,35 @@
+name: Compile
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+
+    strategy:
+      fail-fast: false
+
+      matrix:
+        os: [ubuntu-24.04]
+
+    env:
+      BUILD_DIR: build
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: sudo apt-get install -y libncurses5-dev libncursesw5-dev libdrm-dev libsystemd-dev
+
+    - name: Configure CMake
+      run: cmake -S . -B $BUILD_DIR
+
+    - name: Build
+      run: cmake --build $BUILD_DIR
+      
+    - name: Upload
+      uses: actions/upload-artifact@v4
+      with:
+        path: ${{ env.BUILD_DIR }}/src/nvtop

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ubuntu-24.04]
+        os: [ubuntu-24.04, ubuntu-22.04, ubuntu-20.04]
 
     env:
       BUILD_DIR: build
@@ -32,4 +32,5 @@ jobs:
     - name: Upload
       uses: actions/upload-artifact@v4
       with:
+        name: nvtop ${{ matrix.os }}
         path: ${{ env.BUILD_DIR }}/src/nvtop


### PR DESCRIPTION
Hi,

I'm sorry I broke compiling on Ubuntu 22.04 previously (#343), I've implemented a GitHub workflow to compile for Ubuntu 20.04, 22.04, and 24.04, to prevent that from happening again.

An example run can be found [here](https://github.com/Steve-Tech/nvtop/actions/runs/12368592818).

Thanks,
Steve