### PR TITLE
[DOCUMENTATION] Update gentoo installation in the readme file

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -38,6 +38,7 @@ Table of Contents
   - [Fedora / Red Hat / CentOS](#fedora--red-hat--centos)
   - [OpenSUSE](#opensuse)
   - [Arch Linux](#arch-linux)
+  - [Gentoo](#gentoo)
   - [AppImage](#appimage)
   - [Snap](#snap)
   - [Conda-forge](#conda-forge)
@@ -270,7 +271,7 @@ Build process for OpenSUSE:
 ### Gentoo
 
 - ```bash
-  sudo layman -a guru && sudo emerge -av nvtop
+  sudo emerge -av nvtop
   ```
 
 ### AppImage


### PR DESCRIPTION
`nvtop` has been recently added in the [main gentoo repo](https://packages.gentoo.org/packages/sys-process/nvtop), so no need to use guru anymore.

Layman is also outdated anyway, as gentoo devs had switched to `eselect repository` instead