### PR TITLE
Fix shared encode/decode not being displayed on AMD

### DIFF
--- a/include/nvtop/interface_internal_common.h
+++ b/include/nvtop/interface_internal_common.h
@@ -59,6 +59,7 @@ struct device_window {
   WINDOW *mem_util_no_enc_and_dec;
   WINDOW *encode_util;
   WINDOW *decode_util;
+  WINDOW *encdec_util;
   WINDOW *fan_speed;
   WINDOW *temperature;
   WINDOW *power_info;

--- a/src/extract_gpuinfo_amdgpu.c
+++ b/src/extract_gpuinfo_amdgpu.c
@@ -796,6 +796,7 @@ static const char drm_amdgpu_enc[] = "drm-engine-enc";
 
 static bool parse_drm_fdinfo_amd(struct gpu_info *info, FILE *fdinfo_file, struct gpu_process *process_info) {
   struct gpu_info_amdgpu *gpu_info = container_of(info, struct gpu_info_amdgpu, base);
+  struct gpuinfo_static_info *static_info = &gpu_info->base.static_info;
   static char *line = NULL;
   static size_t line_buf_size = 0;
   ssize_t count = 0;
@@ -965,6 +966,12 @@ static bool parse_drm_fdinfo_amd(struct gpu_info *info, FILE *fdinfo_file, struc
       cache_entry->client_id.pid = process_info->pid;
       cache_entry->client_id.pdev = gpu_info->base.pdev;
     }
+
+    // The UI only shows the decode usage when `encode_decode_shared` is true
+    // but amdgpu should only use the encode usage field when it is shared.
+    // Lets add both together for good measure.
+    if (static_info->encode_decode_shared)
+      SET_GPUINFO_PROCESS(process_info, decode_usage, process_info->decode_usage + process_info->encode_usage);
 
 #ifndef NDEBUG
     // We should only process one fdinfo entry per client id per update

--- a/src/interface.c
+++ b/src/interface.c
@@ -141,6 +141,9 @@ static void alloc_device_window(unsigned int start_row, unsigned int start_col, 
   dwin->decode_util = newwin(1, size_decode, start_row + 2, start_col + spacer * 3 + size_gpu + size_mem + size_encode);
   if (dwin->decode_util == NULL)
     goto alloc_error;
+  dwin->encdec_util = newwin(1, size_encode * 2, start_row + 2, start_col + spacer * 2 + size_gpu + size_mem);
+  if (dwin->encdec_util == NULL)
+    goto alloc_error;
   // For auto-hide encode / decode window
   dwin->gpu_util_no_enc_or_dec = newwin(1, size_gpu + size_encode / 2 + 1, start_row + 2, start_col);
   if (dwin->gpu_util_no_enc_or_dec == NULL)
@@ -190,6 +193,7 @@ static void free_device_windows(struct device_window *dwin) {
   delwin(dwin->mem_util_no_enc_and_dec);
   delwin(dwin->encode_util);
   delwin(dwin->decode_util);
+  delwin(dwin->encdec_util);
   delwin(dwin->gpu_clock_info);
   delwin(dwin->mem_clock_info);
   delwin(dwin->power_info);
@@ -646,9 +650,11 @@ static void draw_devices(struct list_head *devices, struct nvtop_interface *inte
     WINDOW *mem_util_win;
     WINDOW *encode_win = dev->encode_util;
     WINDOW *decode_win = dev->decode_util;
-    if (display_encode && display_decode) {
+    if ((display_encode && display_decode) || (display_decode && device->static_info.encode_decode_shared)) {
       gpu_util_win = dev->gpu_util_enc_dec;
       mem_util_win = dev->mem_util_enc_dec;
+      if (device->static_info.encode_decode_shared)
+        decode_win = dev->encdec_util;
     } else {
       if (display_encode || display_decode) {
         // If encode only, place at decode location


### PR DESCRIPTION
Hi,

The UI only shows the decode usage when `encode_decode_shared` is true but amdgpu will only use the encode usage field when it is shared, causing nvtop to never show any usage. I've now made it save the usage to the decode usage field when it's shared.
#352 seems related, but seemingly not solved.

I also made the ENC/DEC field longer, so that there's a proper usage bar and `100%` doesn't look bad.
Before:
![image](https://github.com/user-attachments/assets/bbc4ffce-f020-469e-8596-12e934432004)
After:
![image](https://github.com/user-attachments/assets/f5946cb1-d867-4f4b-a68a-c27a43045721)

Thanks,
Steve