### PR TITLE
Fix minor build issue for ascend nvtop

### DIFF
--- a/src/extract_gpuinfo_ascend.c
+++ b/src/extract_gpuinfo_ascend.c
@@ -19,6 +19,7 @@
  */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <stdbool.h>
 #include <string.h>
 #include <errno.h>


### PR DESCRIPTION
Fixes a build issue when using the -DASCEND_SUPPORT=ON option (‘EXIT_FAILURE’ undeclared) by including stdlib.h. 