### PR TITLE
Add snapshot flag for scripting purposes

### DIFF
--- a/include/nvtop/interface.h
+++ b/include/nvtop/interface.h
@@ -55,4 +55,6 @@ int interface_update_interval(const struct nvtop_interface *interface);
 
 bool show_information_messages(unsigned num_messages, const char **messages);
 
-#endif // INTERFACE_H_
+void print_snapshot(struct list_head *devices, bool use_fahrenheit_option);
+
+#endif // INTERFACE_H_e

--- a/include/nvtop/interface.h
+++ b/include/nvtop/interface.h
@@ -57,4 +57,4 @@ bool show_information_messages(unsigned num_messages, const char **messages);
 
 void print_snapshot(struct list_head *devices, bool use_fahrenheit_option);
 
-#endif // INTERFACE_H_e
+#endif // INTERFACE_H_

--- a/src/interface.c
+++ b/src/interface.c
@@ -2055,3 +2055,72 @@ bool show_information_messages(unsigned num_messages, const char **messages) {
   }
   return dontShowAgainOption;
 }
+
+void print_snapshot(struct list_head *devices, bool use_fahrenheit_option) {
+  gpuinfo_populate_static_infos(devices);
+  gpuinfo_refresh_dynamic_info(devices);
+  struct gpu_info *device;
+
+  list_for_each_entry(device, devices, list) {
+    // Device Name
+    if (GPUINFO_STATIC_FIELD_VALID(&device->static_info, device_name))
+      printf("Device: %s; ", device->static_info.device_name);
+    else
+      printf("Device: N/A; ");
+
+    // GPU Clock Speed
+    if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, gpu_clock_speed))
+      printf("GPU Clock: %uMHz; ", device->dynamic_info.gpu_clock_speed);
+    else
+      printf("GPU Clock: N/A; ");
+
+    // MEM Clock Speed
+    if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, mem_clock_speed))
+      printf("Mem Clock: %uMHz; ", device->dynamic_info.mem_clock_speed);
+    else
+      printf("Mem Clock: N/A; ");
+
+    // GPU Temperature
+    if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, gpu_temp)) {
+      unsigned int temp_convert;
+      if (!use_fahrenheit_option)
+        temp_convert = device->dynamic_info.gpu_temp;
+      else
+        temp_convert = (unsigned)(32 + nearbyint(device->dynamic_info.gpu_temp * 1.8));
+
+      printf("Temp: %u%s; ", temp_convert, use_fahrenheit_option ? "F" : "C");
+    } else {
+      printf("Temp: N/A; ");
+    }
+
+    // Fan speed
+    if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, fan_speed))
+      printf("Fan: %u%%; ", device->dynamic_info.fan_speed > 100 ? 100 : device->dynamic_info.fan_speed);
+    else if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, fan_rpm))
+      printf("Fan: %uRPM; ", device->dynamic_info.fan_rpm > 9999 ? 9999 : device->dynamic_info.fan_rpm);
+    else if (&device->static_info.integrated_graphics)
+      printf("Fan: CPU Fan; ");
+    else
+      printf("Fan: N/A; ");
+
+    //Power draw
+    if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, power_draw))
+      printf("Power: %uW; ", device->dynamic_info.power_draw / 1000);
+    else
+      printf("Power: N/A; ");
+
+    // GPU Utilization
+    if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, gpu_util_rate))
+      printf("GPU Util: %u%%; ", device->dynamic_info.gpu_util_rate);
+    else
+      printf("GPU Util: N/A; ");
+
+    // Memory Utilization
+    if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, mem_util_rate))
+      printf("Mem Util: %u%%; ", device->dynamic_info.mem_util_rate);
+    else
+      printf("Mem Util: N/A; ");
+
+    printf("\n");
+  }
+}

--- a/src/interface.c
+++ b/src/interface.c
@@ -2061,24 +2061,39 @@ void print_snapshot(struct list_head *devices, bool use_fahrenheit_option) {
   gpuinfo_refresh_dynamic_info(devices);
   struct gpu_info *device;
 
+  printf("[\n");
   list_for_each_entry(device, devices, list) {
+    const char *indent_level_two = "  ";
+    const char *indent_level_four = "   ";
+
+    const char *device_name_field = "device_name";
+    const char *gpu_clock_field = "gpu_clock";
+    const char *mem_clock_field = "mem_clock";
+    const char *temp_field = "temp";
+    const char *fan_field = "fan_speed";
+    const char *power_field = "power_draw";
+    const char *gpu_util_field = "gpu_util";
+    const char *mem_util_field = "mem_util";
+
+    printf("%s{\n", indent_level_two);
+
     // Device Name
     if (GPUINFO_STATIC_FIELD_VALID(&device->static_info, device_name))
-      printf("Device: %s; ", device->static_info.device_name);
+      printf("%s\"%s\": \"%s\",\n", indent_level_four, device_name_field, device->static_info.device_name);
     else
-      printf("Device: N/A; ");
+      printf("%s\"%s\": null,\n", indent_level_four, device_name_field);
 
     // GPU Clock Speed
     if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, gpu_clock_speed))
-      printf("GPU Clock: %uMHz; ", device->dynamic_info.gpu_clock_speed);
+      printf("%s\"%s\": \"%uMHz\",\n", indent_level_four, gpu_clock_field, device->dynamic_info.gpu_clock_speed);
     else
-      printf("GPU Clock: N/A; ");
+      printf("%s\"%s\": null,\n", indent_level_four, gpu_clock_field);
 
     // MEM Clock Speed
     if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, mem_clock_speed))
-      printf("Mem Clock: %uMHz; ", device->dynamic_info.mem_clock_speed);
+      printf("%s\"%s\": \"%uMHz\",\n", indent_level_four, mem_clock_field, device->dynamic_info.mem_clock_speed);
     else
-      printf("Mem Clock: N/A; ");
+      printf("%s\"%s\": null,\n", indent_level_four, mem_clock_field);
 
     // GPU Temperature
     if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, gpu_temp)) {
@@ -2088,39 +2103,45 @@ void print_snapshot(struct list_head *devices, bool use_fahrenheit_option) {
       else
         temp_convert = (unsigned)(32 + nearbyint(device->dynamic_info.gpu_temp * 1.8));
 
-      printf("Temp: %u%s; ", temp_convert, use_fahrenheit_option ? "F" : "C");
+      printf("%s\"%s\": \"%u%s\",\n", indent_level_four, temp_field, temp_convert, use_fahrenheit_option ? "F" : "C");
     } else {
-      printf("Temp: N/A; ");
+      printf("%s\"%s\": null,\n", indent_level_four, temp_field);
     }
 
     // Fan speed
     if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, fan_speed))
-      printf("Fan: %u%%; ", device->dynamic_info.fan_speed > 100 ? 100 : device->dynamic_info.fan_speed);
+      printf("%s\"%s\": \"%u%%\",\n", indent_level_four, fan_field,
+             device->dynamic_info.fan_speed > 100 ? 100 : device->dynamic_info.fan_speed);
     else if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, fan_rpm))
-      printf("Fan: %uRPM; ", device->dynamic_info.fan_rpm > 9999 ? 9999 : device->dynamic_info.fan_rpm);
+      printf("%s\"%s\": \"%uRPM\",\n", indent_level_four, fan_field,
+             device->dynamic_info.fan_rpm > 9999 ? 9999 : device->dynamic_info.fan_rpm);
     else if (&device->static_info.integrated_graphics)
-      printf("Fan: CPU Fan; ");
+      printf("%s\"%s\": \"CPU Fan\",\n", indent_level_four, fan_field);
     else
-      printf("Fan: N/A; ");
+      printf("%s\"%s\": null,\n", indent_level_four, fan_field);
 
-    //Power draw
+    // Power draw
     if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, power_draw))
-      printf("Power: %uW; ", device->dynamic_info.power_draw / 1000);
+      printf("%s\"%s\": \"%uW\",\n", indent_level_four, power_field, device->dynamic_info.power_draw / 1000);
     else
-      printf("Power: N/A; ");
+      printf("%s\"%s\": null,\n", indent_level_four, power_field);
 
     // GPU Utilization
     if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, gpu_util_rate))
-      printf("GPU Util: %u%%; ", device->dynamic_info.gpu_util_rate);
+      printf("%s\"%s\": \"%u%%\",\n", indent_level_four, gpu_util_field, device->dynamic_info.gpu_util_rate);
     else
-      printf("GPU Util: N/A; ");
+      printf("%s\"%s\": null,\n", indent_level_four, gpu_util_field);
 
     // Memory Utilization
     if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, mem_util_rate))
-      printf("Mem Util: %u%%; ", device->dynamic_info.mem_util_rate);
+      printf("%s\"%s\": \"%u%%\"\n", indent_level_four, mem_util_field, device->dynamic_info.mem_util_rate);
     else
-      printf("Mem Util: N/A; ");
+      printf("%s\"%s\": null\n", indent_level_four, mem_util_field);
 
-    printf("\n");
+    if (device->list.next == devices)
+      printf("%s}\n", indent_level_two);
+    else
+      printf("%s},\n", indent_level_two);
   }
+  printf("]\n");
 }

--- a/src/nvtop.c
+++ b/src/nvtop.c
@@ -302,6 +302,7 @@ int main(int argc, char **argv) {
       timeout(next_sleep);
     }
     draw_gpu_info_ncurses(numMonitoredGpus, &monitoredGpus, interface);
+
     nvtop_time time_before_sleep, time_after_sleep;
     nvtop_get_current_time(&time_before_sleep);
     int input_char = getch();

--- a/src/nvtop.c
+++ b/src/nvtop.c
@@ -265,7 +265,6 @@ int main(int argc, char **argv) {
   allDevicesOptions.has_gpu_info_bar = allDevicesOptions.has_gpu_info_bar || show_gpu_info_bar;
 
   gpuinfo_populate_static_infos(&monitoredGpus);
-
   unsigned numMonitoredGpus =
       interface_check_and_fix_monitored_gpus(allDevCount, &monitoredGpus, &nonMonitoredGpus, &allDevicesOptions);
 
@@ -302,7 +301,6 @@ int main(int argc, char **argv) {
       int next_sleep = interface_update_interval(interface) - (int)time_slept;
       timeout(next_sleep);
     }
-
     draw_gpu_info_ncurses(numMonitoredGpus, &monitoredGpus, interface);
     nvtop_time time_before_sleep, time_after_sleep;
     nvtop_get_current_time(&time_before_sleep);


### PR DESCRIPTION
Hey there! I've been using nvtop and I love the functionality. I wanted to add an applet to Linux Mint, so I added a flag to output the stats as a static snapshot for that purpose

## Purpose

Adds `-s` flag to cli to aid in scripting the output of nvtop

## Details

When I first started trying to use nvtop for scripting out an applet (for Linux Mint Cinnamon desktop environment), ncurses wasn't playing nice with the runtime for the applets. I couldn't find any suitable alternatives that gave me the information I was looking for, so I decided to modify nvtop for my personal use case and thought others may be able to get some benefit from it as well.

This doesn't modify any core functionality of the application, and simply bypasses the ncurses initialization in order to print a static snapshot to STDOUT.

## Screenshots

The command + output (updated 02/22 to reflect json output)

```bash
/home/xxxxxxxx/nvtop-dev/usr/local/bin/nvtop -s 
                          
[
  {
   "device_name": "AMD Radeon RX 7700S",
   "gpu_clock": "365MHz",
   "mem_clock": "96MHz",
   "temp": "38C",
   "fan_speed": "29%",
   "power_draw": "2W",
   "gpu_util": "0%",
   "mem_util": "0%"
  },
  {
   "device_name": "AMD Radeon 780M Graphics",
   "gpu_clock": "800MHz",
   "mem_clock": "2800MHz",
   "temp": "51C",
   "fan_speed": "CPU Fan",
   "power_draw": "29W",
   "gpu_util": "32%",
   "mem_util": "23%"
  }
]
```

The resulting "applet" that I created using the output

![image](https://github.com/user-attachments/assets/bddba4c8-9f4d-403e-9093-e66d18b44370)

And a bonus using the output to show the stats in a conky theme

![image](https://github.com/user-attachments/assets/128c22bd-a6d3-41de-8a0e-4254d6acdb41)

## Disclaimers

I am not a C developer. I've never actually written in C before, so this was a great learning experience for me.

Thanks for taking a look!