### PR TITLE
fix readme: make DESTDIR will prepend DESTDIR; switch to CMAKE_INSTALL_PREFIX

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -347,7 +347,9 @@ make
 sudo make install
 
 # Alternatively, install without privileges at a location of your choosing
-# make DESTDIR="/your/install/path" install
+# cmake .. -DNVIDIA_SUPPORT=ON -DAMDGPU_SUPPORT=ON -DINTEL_SUPPORT=ON -DCMAKE_INSTALL_PREFIX=/path/to/your/dir
+# make
+# make install
 ```
 
 If you use **conda** as environment manager and encounter an error while building NVTOP, try `conda deactivate` before invoking `cmake`.


### PR DESCRIPTION
Dear developer,

thanks for developing this fantastic program.

I found `make DESTDIR="/path/to/something" install` does not work as expected. It does not remove the default `/usr/local` installation prefix, but prepend to it. In my experiment,

```bash
[23:30]wukai111@nid006454:~/user-software/nvtop/build$ make DESTDIR="/users/wukai111/user-software" install
Consolidate compiler generated dependencies of target nvtop
[100%] Built target nvtop
Install the project...
-- Install configuration: "Release"
-- Installing: /users/wukai111/user-software/usr/local/bin/nvtop
-- Set runtime path of "/users/wukai111/user-software/usr/local/bin/nvtop" to "/usr/local/lib"
-- Installing: /users/wukai111/user-software/usr/local/share/man/man1/nvtop.1
-- Installing: /users/wukai111/user-software/usr/local/share/icons/nvtop.svg
-- Installing: /users/wukai111/user-software/usr/local/share/applications/nvtop.desktop
-- Installing: /users/wukai111/user-software/usr/local/share/metainfo/nvtop.metainfo.xml
```

This is not what I love. However, switching to CMAKE_INSTALL_PREFIX aligns with with my expectation:

```bash
[23:31]wukai111@nid006454:~/user-software/nvtop/build$ cmake .. -DAMDGPU_SUPPORT=ON -DCMAKE_INSTALL_PREFIX=/users/wukai111/user-software  
# note: here because I did cmake and make once right before this one, so some steps were omitted this time by cmake and make
-- Cray Programming Environment 2.7.31.11 C
-- Cray Programming Environment 2.7.31.11 CXX
-- Libudev stable: TRUE
-- Found libdrm; Enabling support
-- Could NOT find GTest (missing: GTEST_LIBRARY GTEST_INCLUDE_DIR GTEST_MAIN_LIBRARY)
-- Configuring done
-- Generating done
-- Build files have been written to: /users/wukai111/user-software/nvtop/build
[23:32]wukai111@nid006454:~/user-software/nvtop/build$ make
Consolidate compiler generated dependencies of target nvtop
[  3%] Linking C executable nvtop
[100%] Built target nvtop
[23:32]wukai111@nid006454:~/user-software/nvtop/build$ make install
[100%] Built target nvtop
Install the project...
-- Install configuration: "Release"
-- Installing: /users/wukai111/user-software/bin/nvtop
-- Set runtime path of "/users/wukai111/user-software/bin/nvtop" to "/users/wukai111/user-software/lib"
-- Installing: /users/wukai111/user-software/share/man/man1/nvtop.1
-- Installing: /users/wukai111/user-software/share/icons/nvtop.svg
-- Installing: /users/wukai111/user-software/share/applications/nvtop.desktop
-- Installing: /users/wukai111/user-software/share/metainfo/nvtop.metainfo.xml
```

This is exactly what I expect, because under my `user-software` dir, I have `bin`, `share`, `lib` to also put other apps built from source.

Thanks for your time to read this message.

Regards, Kai