### PR TITLE
icon location should be share/pixmaps per the xdg .desktop spec

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,7 +142,7 @@ install(FILES
   RENAME nvtop.1)
 install(FILES
   "${CMAKE_CURRENT_SOURCE_DIR}/desktop/nvtop.svg"
-  DESTINATION share/icons
+  DESTINATION share/pixmaps
   PERMISSIONS OWNER_READ OWNER_WRITE GROUP_READ WORLD_READ)
 install(FILES
   "${CMAKE_CURRENT_SOURCE_DIR}/desktop/nvtop.desktop"


### PR DESCRIPTION
fixes #212 

icon location for the nvtop.desktop file should be in /usr/share/pixmaps, per the spec:
https://specifications.freedesktop.org/icon-theme-spec/latest/#directory_layout