### PR TITLE
Fix linking of tests in 3.1.0 and 3.2.0

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -5,6 +5,7 @@ if (BUILD_TESTING AND GTest_FOUND)
 
   # Create a library for testing
   add_library(testLib
+    ${PROJECT_SOURCE_DIR}/src/extract_processinfo_fdinfo.c
     ${PROJECT_SOURCE_DIR}/src/interface_layout_selection.c
     ${PROJECT_SOURCE_DIR}/src/extract_processinfo_fdinfo.c
     ${PROJECT_SOURCE_DIR}/src/interface_options.c


### PR DESCRIPTION
From Fedora's packaging, https://src.fedoraproject.org/rpms/nvtop/c/d134ec03ad6dc35e6b7352a5068f8ab325968fba?branch=rawhide