### PR TITLE
Replace unmaintained ppa with quentiumyt

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -157,20 +157,19 @@ If your distribution provides the snap utility, follow the [snap installation pr
 
 A standalone application is available as [AppImage](#appimage).
 
-#### Ubuntu Impish (21.10), Debian buster (stable) and more recent
+#### Ubuntu Focal (20.04), Debian buster (stable) and more recent
 
-- ```bash
-  sudo apt install nvtop
-  ```
+```bash
+sudo apt install nvtop
+```
 
 #### Ubuntu PPA
 
-A [PPA supporting Ubuntu 20.04, 22.04 and newer](https://launchpad.net/~flexiondotorg/+archive/ubuntu/nvtop) is provided by
-[Martin Wimpress](https://github.com/flexiondotorg) that offers an up-to-date
-version of `nvtop`, enabled for NVIDIA, AMD and Intel.
+A [PPA supporting Ubuntu 20.04 and newer](https://launchpad.net/~quentiumyt/+archive/ubuntu/nvtop) is provided by
+[Quentin Lienhardt](https://github.com/QuentiumYT) that offers an up-to-date version of `nvtop`, enabled for NVIDIA, AMD and Intel.
 
 ```bash
-sudo add-apt-repository ppa:flexiondotorg/nvtop
+sudo add-apt-repository ppa:quentiumyt/nvtop
 sudo apt install nvtop
 ```
 


### PR DESCRIPTION
Hello, it's been a while I follow this project and use it, so thank you for that.

I added some files 2 years ago (September 2023) to build it and make releases easily and publish to my PPA when a new release was out. Since the release of 3.2.0, I decided to publish it differently, using a github action from yuezk. We adapted the script a bit and it's now live and working correctly :)

There are now 2 nvtop builds in quentiumyt:nvtop, one build every release, one with nightly builds (triggered by hand) with specific features from commits. I plan to keep it updated when I see new releases or interesting nightly builds to make :)

Also, nvtop 1.0.0 exists in Focal multiverse so I fixed the typo

Feel free to discuss about that