### PR TITLE
Fix matrix duplicate OS

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -12,7 +12,7 @@ jobs:
       fail-fast: false
 
       matrix:
-        os: [ubuntu-latest, ubuntu-24.04, ubuntu-22.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
 
     env:
       BUILD_DIR: build


### PR DESCRIPTION
Recently, ubuntu 20.04 has been dropped. When updating the CI workflow, you added `ubuntu-latest` which is the equivalent of `ubuntu-24.04` already.

See https://github.com/actions/runner-images#available-images