### PR TITLE
Use fdinfo's engine count when refreshing utilisation rate

### DIFF
--- a/include/nvtop/extract_gpuinfo_common.h
+++ b/include/nvtop/extract_gpuinfo_common.h
@@ -60,6 +60,7 @@ enum gpuinfo_static_info_valid {
   gpuinfo_n_shared_cores_valid,
   gpuinfo_l2cache_size_valid,
   gpuinfo_n_exec_engines_valid,
+  gpuinfo_engine_count_valid,
   gpuinfo_static_info_count,
 };
 
@@ -74,6 +75,7 @@ struct gpuinfo_static_info {
   unsigned n_shared_cores;
   unsigned l2cache_size;
   unsigned n_exec_engines;
+  unsigned engine_count;
   bool integrated_graphics;
   bool encode_decode_shared;
   unsigned char valid[(gpuinfo_static_info_count + CHAR_BIT - 1) / CHAR_BIT];

--- a/src/extract_gpuinfo.c
+++ b/src/extract_gpuinfo.c
@@ -340,6 +340,7 @@ void gpuinfo_refresh_utilisation_rate(struct gpu_info *gpu_info) {
   unsigned int utilisation_rate;
   uint64_t max_freq_hz;
   double avg_delta_secs;
+  unsigned int ec;
 
   for (unsigned processIdx = 0; processIdx < gpu_info->processes_count; ++processIdx) {
     struct gpu_process *process_info = &gpu_info->processes[processIdx];
@@ -351,9 +352,14 @@ void gpuinfo_refresh_utilisation_rate(struct gpu_info *gpu_info) {
   if (!gfx_total_process_cycles)
     return;
 
+  if (IS_VALID(gpuinfo_engine_count_valid, gpu_info->static_info.valid))
+          ec = gpu_info->static_info.engine_count;
+  else
+          ec = 1;
+
   avg_delta_secs = ((double)total_delta / gpu_info->processes_count) / 1000000000.0;
   max_freq_hz = gpu_info->dynamic_info.gpu_clock_speed_max * 1000000;
-  utilisation_rate = (unsigned int)((((double)gfx_total_process_cycles) / (((double)max_freq_hz) * avg_delta_secs * 2)) * 100);
+  utilisation_rate = (unsigned int)((((double)gfx_total_process_cycles) / (((double)max_freq_hz) * avg_delta_secs * ec)) * 100);
   utilisation_rate = utilisation_rate > 100 ? 100 : utilisation_rate;
 
   SET_GPUINFO_DYNAMIC(&gpu_info->dynamic_info, gpu_util_rate, utilisation_rate);

--- a/src/extract_gpuinfo_mali_common.c
+++ b/src/extract_gpuinfo_mali_common.c
@@ -456,6 +456,7 @@ bool mali_common_parse_drm_fdinfo(struct gpu_info *info, FILE *fdinfo_file,
 				  check_fdinfo_keys match_keys,
 				  struct fdinfo_data *fid)
 {
+  struct gpuinfo_static_info *static_info = &info->static_info;
   static char *line = NULL;
   static size_t line_buf_size = 0;
   uint64_t total_time = 0;
@@ -529,8 +530,10 @@ bool mali_common_parse_drm_fdinfo(struct gpu_info *info, FILE *fdinfo_file,
     }
   }
 
-  if (fid->engine_count)
-    SET_GPUINFO_PROCESS(process_info, gfx_engine_used, total_time);
+  if (fid->engine_count) {
+          SET_GPUINFO_PROCESS(process_info, gfx_engine_used, total_time);
+          SET_GPUINFO_STATIC(static_info, engine_count, fid->engine_count);
+  }
 
   if (!client_id_set)
     return false;


### PR DESCRIPTION
I originally moved gpuinfo_refresh_utilisation_rate() from Mali code into src/extract_gpuinfo.c when I realised utilisation rate could be calculated in a device-independent way simply by following the percentage utilisation guidelines given in
Documentation/gpu/drm-usage-stats.rst

However, I forgot to replace the magic number '2' which stood for the engine count in Mali GPUs with a value that make sense for different devices.

Source the engine count from gpu_info's static information values.