### PR TITLE
Add F5 and Ctrl+L screen refresh functionality

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -1942,6 +1942,10 @@ void interface_key(int keyId, struct nvtop_interface *interface) {
   case 27:
     interface->process.option_window.state = nvtop_option_state_hidden;
     break;
+  case KEY_F(5):
+  case 12: // Ctrl+L
+    update_window_size_to_terminal_size(interface);
+    break;
   default:
     break;
   }

--- a/src/nvtop.c
+++ b/src/nvtop.c
@@ -329,11 +329,13 @@ int main(int argc, char **argv) {
       signal_exit = 1;
       break;
     case KEY_F(2):
+    case KEY_F(5):
     case KEY_F(9):
     case KEY_F(6):
     case KEY_F(12):
     case '+':
     case '-':
+    case 12: // Ctrl+L
       interface_key(input_char, interface);
       break;
     case 'k':


### PR DESCRIPTION
Implements keyboard shortcuts to manually refresh the display:
- F5: Refresh screen and redraw all interface elements
- Ctrl+L: Same as F5, common terminal refresh shortcut

Uses complete window reinitialization to ensure proper redraw of all elements including window borders and frames.

Fixes #394

🤖 Generated with [Claude Code](https://claude.ai/code)