### PR TITLE
Fix incorrect gpu number for METAX GPU

### DIFF
--- a/src/extract_gpuinfo_metax.c
+++ b/src/extract_gpuinfo_metax.c
@@ -43,7 +43,7 @@ static mxSmlReturn_t (*mxSmlInit)(void);
 
 // Static information and helper functions
 
-static mxSmlReturn_t(*mxSmlGetDeviceCount)(unsigned int *deviceCount);
+static unsigned int (*mxSmlGetDeviceCount)(void);
 
 static const char *(*mxSmlGetErrorString)(mxSmlReturn_t);
 
@@ -223,7 +223,6 @@ __attribute__((constructor)) static void init_extract_gpuinfo_metax(void) { regi
  *
  */
 static bool gpuinfo_metax_init(void) {
-  printf("gpuinfo_metax_init\n");
   libmxsml_handle = dlopen("/opt/mxdriver/lib/libmxsml.so", RTLD_LAZY);
   if (!libmxsml_handle)
     libmxsml_handle = dlopen("/opt/maca/lib/libmxsml.so", RTLD_LAZY);
@@ -344,13 +343,10 @@ static const char *gpuinfo_metax_last_error_string(void) {
 }
 
 static bool gpuinfo_metax_get_device_handles(struct list_head *devices, unsigned int *count) {
-  printf("gpuinfo_metax_get_device_handles...\n");
   if (!libmxsml_handle)
     return false;
 
-  unsigned int num_devices;
-  mxSmlGetDeviceCount(&num_devices);
-  printf("device count: %u\n", num_devices);
+  unsigned int num_devices = mxSmlGetDeviceCount();
   struct gpu_info_metax *gpu_infos = calloc(num_devices, sizeof(*gpu_infos));
   if (!gpu_infos) {
     local_error_string = strerror(errno);
@@ -364,7 +360,7 @@ static bool gpuinfo_metax_get_device_handles(struct list_head *devices, unsigned
     mxSmlDeviceInfo_t deviceInfo;
     mxSmlReturn_t deviceInfoRet = mxSmlGetDeviceInfo(i, &deviceInfo);
     if (deviceInfoRet != MXSML_SUCCESS) {
-      deviceInfoRet != mxSmlGetLimitedDeviceInfo(i, &deviceInfo);
+      deviceInfoRet = mxSmlGetLimitedDeviceInfo(i, &deviceInfo);
       // Limited device
       if (deviceInfoRet == MXSML_SUCCESS) {
         gpu_infos[*count].device = deviceInfo;


### PR DESCRIPTION
Incorrectly defined function return type and parameters, leading to wrong GPU count retrieval.