### PR TITLE
Fix assertion failure when duplicate client_id encountered

### DIFF
--- a/src/extract_gpuinfo_amdgpu.c
+++ b/src/extract_gpuinfo_amdgpu.c
@@ -975,12 +975,17 @@ static bool parse_drm_fdinfo_amd(struct gpu_info *info, FILE *fdinfo_file, struc
     if (static_info->encode_decode_shared)
       SET_GPUINFO_PROCESS(process_info, decode_usage, process_info->decode_usage + process_info->encode_usage);
 
-#ifndef NDEBUG
-    // We should only process one fdinfo entry per client id per update
+    // Check if we already processed this client_id in the current update cycle.
+    // This can happen when a process has multiple file descriptors referencing
+    // the same DRM client (e.g., via DRM master operations).
     struct amdgpu_process_info_cache *cache_entry_check;
     HASH_FIND_CLIENT(gpu_info->current_update_process_cache, &cache_entry->client_id, cache_entry_check);
-    assert(!cache_entry_check && "We should not be processing a client id twice per update");
-#endif
+    if (cache_entry_check) {
+      // Already processed this client_id, free the entry if we allocated it
+      if (cache_entry != cache_entry_check)
+        free(cache_entry);
+      goto parse_fdinfo_exit;
+    }
 
     // Store this measurement data
     RESET_ALL(cache_entry->valid);

--- a/src/extract_gpuinfo_intel_i915.c
+++ b/src/extract_gpuinfo_intel_i915.c
@@ -303,12 +303,17 @@ bool parse_drm_fdinfo_intel_i915(struct gpu_info *info, FILE *fdinfo_file, struc
     cache_entry->client_id.pdev = gpu_info->base.pdev;
   }
 
-#ifndef NDEBUG
-  // We should only process one fdinfo entry per client id per update
+  // Check if we already processed this client_id in the current update cycle.
+  // This can happen when a process has multiple file descriptors referencing
+  // the same DRM client (e.g., via DRM master operations).
   struct intel_process_info_cache *cache_entry_check;
   HASH_FIND_CLIENT(gpu_info->current_update_process_cache, &cache_entry->client_id, cache_entry_check);
-  assert(!cache_entry_check && "We should not be processing a client id twice per update");
-#endif
+  if (cache_entry_check) {
+    // Already processed this client_id, free the entry if we allocated it
+    if (cache_entry != cache_entry_check)
+      free(cache_entry);
+    goto parse_fdinfo_exit;
+  }
 
   RESET_ALL(cache_entry->valid);
   if (GPUINFO_PROCESS_FIELD_VALID(process_info, gfx_engine_used))

--- a/src/extract_gpuinfo_intel_xe.c
+++ b/src/extract_gpuinfo_intel_xe.c
@@ -254,12 +254,17 @@ bool parse_drm_fdinfo_intel_xe(struct gpu_info *info, FILE *fdinfo_file, struct 
     cache_entry->client_id.pdev = gpu_info->base.pdev;
   }
 
-#ifndef NDEBUG
-  // We should only process one fdinfo entry per client id per update
+  // Check if we already processed this client_id in the current update cycle.
+  // This can happen when a process has multiple file descriptors referencing
+  // the same DRM client (e.g., via DRM master operations).
   struct intel_process_info_cache *cache_entry_check;
   HASH_FIND_CLIENT(gpu_info->current_update_process_cache, &cache_entry->client_id, cache_entry_check);
-  assert(!cache_entry_check && "We should not be processing a client id twice per update");
-#endif
+  if (cache_entry_check) {
+    // Already processed this client_id, free the entry if we allocated it
+    if (cache_entry != cache_entry_check)
+      free(cache_entry);
+    goto parse_fdinfo_exit;
+  }
 
   RESET_ALL(cache_entry->valid);
   SET_INTEL_CACHE(cache_entry, gpu_cycles, gpu_cycles);


### PR DESCRIPTION
## Summary

Fixes the assertion failure crash:
```
nvtop: ./src/extract_gpuinfo_amdgpu.c:964: parse_drm_fdinfo_amd:
Assertion `!cache_entry_check && "We should not be processing a client id twice per update"' failed.
Aborted (core dumped)
```

## Root Cause

The assertion fails when a process has multiple file descriptors referencing the same DRM client (e.g., via `dup()`, `fork()`, or DRM master operations). The `kcmp` syscall filters duplicate file descriptions but not distinct file descriptions that report the same underlying DRM `client_id`.

## Fix

Converts the debug assertion into a runtime check that:
- Detects duplicate `client_id` entries in `current_update_process_cache`
- Gracefully skips duplicates instead of crashing
- Frees newly allocated cache entries to prevent memory leaks

## Files Changed

Applied fix to all affected drivers:
- `extract_gpuinfo_amdgpu.c` - AMD GPUs
- `extract_gpuinfo_intel_i915.c` - Intel i915
- `extract_gpuinfo_intel_xe.c` - Intel Xe  
- `extract_gpuinfo_msm.c` - Qualcomm MSM (also fixed incorrect hash key: was using `&cid` instead of `&cache_entry->client_id`)
- `extract_gpuinfo_mali_common.c` - ARM Mali

## Testing

Tested on AMD GPU where the crash was occurring - nvtop now runs without crashing.