### PR TITLE
Fix NVML library loading order for WSL compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ build/
 cmake-build*/
 .vscode
 .idea
+.cache

--- a/src/extract_gpuinfo_nvidia.c
+++ b/src/extract_gpuinfo_nvidia.c
@@ -271,10 +271,9 @@ __attribute__((constructor)) static void init_extract_gpuinfo_nvidia(void) { reg
  *
  */
 static bool gpuinfo_nvidia_init(void) {
-
-  libnvidia_ml_handle = dlopen("libnvidia-ml.so", RTLD_LAZY);
-  if (!libnvidia_ml_handle)
     libnvidia_ml_handle = dlopen("libnvidia-ml.so.1", RTLD_LAZY);
+  if (!libnvidia_ml_handle)
+    libnvidia_ml_handle = dlopen("libnvidia-ml.so", RTLD_LAZY);
   if (!libnvidia_ml_handle) {
     local_error_string = dlerror();
     return false;


### PR DESCRIPTION
Prioritize libnvidia-ml.so.1 (versioned library name) over libnvidia-ml.so when loading the NVIDIA Management Library.

On WSL systems, ldconfig may register multiple libnvidia-ml.so.1 entries,where /usr/lib/libnvidia-ml.so.1 is a stub and the actual implementation is at /usr/lib/wsl/lib/libnvidia-ml.so.1. Prioritizing the versioned library name ensures the correct implementation is loaded.

```bash
$ ldconfig -p | grep libnvidia-ml
        libnvidia-ml.so.1 (libc6,x86-64) => /usr/lib/wsl/lib/libnvidia-ml.so.1
        libnvidia-ml.so.1 (libc6,x86-64) => /usr/lib/libnvidia-ml.so.1
        libnvidia-ml.so (libc6,x86-64) => /usr/lib/libnvidia-ml.so
```

Fixes #318

## Before
```bash
$ nvtop --version
nvtop version 3.3.2
$ nvtop
No GPU to monitor.
```

## After
```bash
$ ./build/src/nvtop -s
[
  {
    "device_name": "NVIDIA GeForce RTX 5070 Ti",
    "gpu_clock": "180MHz",
    "mem_clock": "14001MHz",
    "temp": "47C",
    "fan_speed": "0%",
    "power_draw": "30W",
    "gpu_util": "1%",
    "encode": "0%",
    "decode": "0%",
    "mem_util": "35%",
    "mem_total": "17094934528",
    "mem_used": "6088810496",
    "mem_free": "11006124032",
    "processes": []
  }
]
```