### PR TITLE
dockerfile-fix-for-docker-build-on-win11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@
 
 ARG IMAGE=nvidia/opengl:1.2-glvnd-runtime-ubuntu20.04
 
-FROM ${IMAGE} as builder
+FROM ${IMAGE} AS builder
 
 ENV DEBIAN_FRONTEND=noninteractive
 


### PR DESCRIPTION
dockerfile-fix-for-docker-build-on-win11

fixing Dockerfile for running on windows as building the container atm returns error:

```
 1 warning found:
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 9)
The 'as' keyword should match the case of the 'from' keyword
More info: https://docs.docker.com/go/dockerfile/rule/from-as-casing/
Dockerfile:9
--------------------
   7 |     ARG IMAGE=nvidia/opengl:1.2-glvnd-runtime-ubuntu20.04
   8 |
   9 | >>> FROM ${IMAGE} as builder
  10 |
  11 |     ENV DEBIAN_FRONTEND=noninteractive
--------------------
```