### PR TITLE
MSM gpu ids

### DIFF
--- a/src/extract_gpuinfo_msm.c
+++ b/src/extract_gpuinfo_msm.c
@@ -477,10 +477,6 @@ void gpuinfo_msm_populate_static_info(struct gpu_info *_gpu_info) {
   uint64_t gpuid;
   if (gpuinfo_msm_query_param(gpu_info->fd, MSM_PARAM_CHIP_ID, &gpuid) == 0) {
     const char* name = msm_parse_marketing_name(gpuid);
-    if (!name) {
-      // Try again ignoring speed-bin in the upper bits.
-      name = msm_parse_marketing_name(gpuid & 0x0000ffffffff);
-    }
 
     if (name) {
       strncpy(static_info->device_name, name, sizeof(static_info->device_name));

--- a/src/extract_gpuinfo_msm_utils.c
+++ b/src/extract_gpuinfo_msm_utils.c
@@ -21,7 +21,7 @@
 #include <stdint.h>
 
 struct msm_id_struct {
-  uint64_t id;
+  uint64_t chip_id;
   const char *name;
 };
 
@@ -92,12 +92,46 @@ static const struct msm_id_struct msm_ids[] = {
   {0x000043051401, "Adreno 750"},
 };
 
-const char * msm_parse_marketing_name(uint64_t gpu_id);
+const char * msm_parse_marketing_name(uint64_t chip_id);
 
-const char * msm_parse_marketing_name(uint64_t gpu_id) {
+const char * msm_parse_marketing_name(uint64_t chip_id) {
   for (unsigned i = 0; i < ARRAY_SIZE(msm_ids); i++) {
-    if (gpu_id == msm_ids[i].id) {
-      return msm_ids[i].name;
+    /* Reference entry from device table: */
+    const struct msm_id_struct *ref = &msm_ids[i];
+
+    /* Match on either:
+     * (a) exact match:
+     */
+    if (ref->chip_id == chip_id)
+        return ref->name;
+
+    /* (b) device table entry has 0xff wildcard patch_id and core/
+     *     major/minor match:
+     */
+    if (((ref->chip_id & 0xff) == 0xff) &&
+         ((ref->chip_id & UINT64_C(0xffffff00)) ==
+          (chip_id & UINT64_C(0xffffff00))))
+      return ref->name;
+
+  #define WILDCARD_FUSE_ID UINT64_C(0x0000ffff00000000)
+    /* If the reference id has wildcard fuse-id value (ie. bits 47..32
+     * are all ones, then try matching ignoring the device fuse-id:
+     */
+    if ((ref->chip_id & WILDCARD_FUSE_ID) == WILDCARD_FUSE_ID) {
+      uint64_t new_chip_id = chip_id | WILDCARD_FUSE_ID;
+
+      /* (c) exact match (ignoring the fuse-id from kernel):
+       */
+      if (ref->chip_id == new_chip_id)
+        return ref->name;
+
+      /* (d) device table entry has 0xff wildcard patch_id and core/
+       *     major/minor match (ignoring fuse-id from kernel):
+       */
+      if (((ref->chip_id & 0xff) == 0xff) &&
+           ((ref->chip_id & UINT64_C(0xffffff00)) ==
+            (new_chip_id & UINT64_C(0xffffff00))))
+        return ref->name;
     }
   }
 

--- a/src/extract_gpuinfo_msm_utils.c
+++ b/src/extract_gpuinfo_msm_utils.c
@@ -25,71 +25,76 @@ struct msm_id_struct {
   const char *name;
 };
 
-#define GetHundredDigit(coreid) (coreid / 100)
-#define GetHundred(coreid) (GetHundredDigit(coreid) * 100)
-#define GetTenDigit(coreid) ((coreid - GetHundred(coreid)) / 10)
-#define GetTen(coreid) (GetTenDigit(coreid) * 10)
-#define GetOneDigit(coreid) (coreid - (GetHundred(coreid) + GetTen(coreid)))
-
-#define CHIPID(coreid) \
-  (GetHundredDigit(coreid) << 24) | \
-  (GetTenDigit(coreid) << 16) | \
-  (GetOneDigit(coreid) << 8)
-
 static const struct msm_id_struct msm_ids[] = {
-  // Adreno 2xx
-  {CHIPID(200),   "Adreno 200"},
-  {CHIPID(201),   "Adreno 201"},
-  {CHIPID(205),   "Adreno 205"},
-  {CHIPID(220),   "Adreno 220"},
-
-  // Adreno 3xx
-  {CHIPID(305),   "Adreno 305"},
-  {CHIPID(307),   "Adreno 307"},
-  {CHIPID(320),   "Adreno 320"},
-  {CHIPID(330),   "Adreno 330"},
-
-  // Adreno 4xx
-  {CHIPID(405),   "Adreno 405"},
-  {CHIPID(420),   "Adreno 420"},
-  {CHIPID(430),   "Adreno 430"},
-
-  // Adreno 5xx
-  {CHIPID(508),   "Adreno 508"},
-  {CHIPID(509),   "Adreno 509"},
-  {CHIPID(510),   "Adreno 510"},
-  {CHIPID(512),   "Adreno 512"},
-  {CHIPID(530),   "Adreno 530"},
-  {CHIPID(540),   "Adreno 540"},
-
-  // Adreno 6xx
-  {CHIPID(615),    "Adreno 615"},
-  {CHIPID(616),    "Adreno 616"},
-  {CHIPID(618),    "Adreno 618"},
-  {CHIPID(619),    "Adreno 619"},
-  {CHIPID(620),    "Adreno 620"},
-  {CHIPID(630),    "Adreno 630"},
-  {CHIPID(640),    "Adreno 640"},
-  // QCM6490
-  {0x00ac06030500, "Adreno 643"},
-  {CHIPID(650),    "Adreno 650"},
-  {CHIPID(660),    "Adreno 660"},
-  {CHIPID(680),    "Adreno 680"},
-  {CHIPID(690),    "Adreno 690"},
-  // no-speedbin Adreno 690
-  {0xffff06090000, "Adreno 690"},
-
-  // Adreno 7xx
-  {CHIPID(730),   "Adreno 730"},
-  {CHIPID(740),   "Adreno 740"},
-  {CHIPID(750),   "Adreno 750"},
-  {CHIPID(790),   "Adreno 750"},
-
-  // Misc
-  {0x00be06030500, "Adreno 8c Gen 3"},
-  {0x007506030500, "Adreno 7c+ Gen 3"},
-  {0x006006030500, "Adreno 7c+ Gen 3 Lite"},
-  {0x000043051401, "Adreno 750"},
+   { 0x20000ff, "FD200" },
+   { 0x20001ff, "FD201" },
+   { 0x20005ff, "FD205" },
+   { 0x20200ff, "FD220" },
+   { 0x30005ff, "FD305" },
+   { 0x30007ff, "FD307" },
+   { 0x30200ff, "FD320" },
+   { 0x30300ff, "FD330" },
+   { 0x3000512, "FD305B" },
+   { 0x3000620, "FD306A" },
+   { 0x40005ff, "FD405" },
+   { 0x40200ff, "FD420" },
+   { 0x40300ff, "FD430" },
+   { 0x50005ff, "FD505" },
+   { 0x50006ff, "FD506" },
+   { 0x50008ff, "FD508" },
+   { 0x50009ff, "FD509" },
+   { 0x50100ff, "FD510" },
+   { 0x50102ff, "FD512" },
+   { 0x50300ff, "FD530" },
+   { 0x50400ff, "FD540" },
+   { 0x60005ff, "FD605" },
+   { 0x60008ff, "FD608" },
+   { 0x60100ff, "FD610" },
+   { 0x60102ff, "FD612" },
+   { 0x60105ff, "FD615" },
+   { 0x60106ff, "FD616" },
+   { 0x60108ff, "FD618" },
+   { 0x60109ff, "FD619" },
+   { 0x60200ff, "FD620" },
+   { 0xffff06020100, "FD621" },
+   { 0xffff06020300, "Adreno623" },
+   { 0x60300ff, "FD630" },
+   { 0x60400ff, "FD640" },
+   { 0x60800ff, "FD680" },
+   { 0x60500ff, "FD650" },
+   { 0xbe06030500, "Adreno 8c Gen 3" },
+   { 0x7506030500, "Adreno 7c+ Gen 3" },
+   { 0x6006030500, "Adreno 7c+ Gen 3 Lite" },
+   { 0xac06030500, "FD643" },
+   { 0xffff06030500, "Adreno 7c+ Gen 3" },
+   { 0x60600ff, "FD660" },
+   { 0x6060201, "FD644" },
+   { 0xffff06060300, "FD663" },
+   { 0x60900ff, "FD690" },
+   { 0xffff06090000, "FD690" },
+   { 0x70002ff, "FD702" },
+   { 0xb207002000, "FD702" },
+   { 0xffff07002000, "FD702" },
+   { 0x7030002, "FD725" },
+   { 0xffff07030002, "FD725" },
+   { 0x7030001, "FD730" },
+   { 0xffff07030001, "FD730" },
+   { 0xffff43030c00, "Adreno X1-45" },
+   { 0x43030b00, "FD735" },
+   { 0x70400ff, "FD740" },
+   { 0x43050a01, "FD740" },
+   { 0xffff43050a01, "FD740" },
+   { 0xffff43050c01, "Adreno X1-85" },
+   { 0x43050a00, "FDA32" },
+   { 0xffff43050a00, "FDA32" },
+   { 0x43050b00, "FD740v3" },
+   { 0xffff43050b00, "FD740v3" },
+   { 0x43051401, "FD750" },
+   { 0xffff43051401, "FD750" },
+   { 0x44050000, "Adreno (TM) 830" },
+   { 0x44050001, "Adreno (TM) 830" },
+   { 0xffff44050a31, "Adreno (TM) 840" },
+   { 0xffff44070041, "Adreno (TM) X2-85" },
 };
 
 const char * msm_parse_marketing_name(uint64_t chip_id);


### PR DESCRIPTION
- Rework chip_id matching rules to align with mesa
- Generate GPU ID table from mesa

See https://gitlab.freedesktop.org/mesa/mesa/-/merge_requests/40283

We probably don't want to merge this until the mesa side is merged.  Feel free to leave comments here or on mesa MR.
