### PR TITLE
Handle NVIDIA UMA memory fallback

### DIFF
--- a/src/extract_gpuinfo.c
+++ b/src/extract_gpuinfo.c
@@ -166,7 +166,7 @@ bool gpuinfo_fix_dynamic_info_from_process_info(struct list_head *devices) {
         }
         if (needGPUMemory && GPUINFO_PROCESS_FIELD_VALID(process_info, gpu_memory_usage)) {
           if (GPUINFO_DYNAMIC_FIELD_VALID(dynamic_info, used_memory)) {
-            dynamic_info->used_memory += dynamic_info->used_memory + process_info->gpu_memory_usage;
+            dynamic_info->used_memory += process_info->gpu_memory_usage;
           } else {
             SET_GPUINFO_DYNAMIC(dynamic_info, used_memory, process_info->gpu_memory_usage);
           }

--- a/src/extract_gpuinfo_nvidia.c
+++ b/src/extract_gpuinfo_nvidia.c
@@ -214,6 +214,46 @@ static char didnt_call_gpuinfo_init[] = "The NVIDIA extraction has not been init
                                         "gpuinfo_nvidia_init\n";
 static const char *local_error_string = didnt_call_gpuinfo_init;
 
+static bool set_unified_system_memory_info(struct gpuinfo_dynamic_info *dynamic_info) {
+  FILE *meminfo = fopen("/proc/meminfo", "r");
+  if (!meminfo)
+    return false;
+
+  unsigned long long total_memory_kb = 0;
+  unsigned long long available_memory_kb = 0;
+  bool total_memory_found = false;
+  bool available_memory_found = false;
+  char line[256];
+
+  while (fgets(line, sizeof(line), meminfo)) {
+    if (sscanf(line, "MemTotal: %llu kB", &total_memory_kb) == 1) {
+      total_memory_found = true;
+      continue;
+    }
+    if (sscanf(line, "MemAvailable: %llu kB", &available_memory_kb) == 1) {
+      available_memory_found = true;
+      continue;
+    }
+  }
+
+  fclose(meminfo);
+
+  if (!total_memory_found || !available_memory_found || total_memory_kb == 0 ||
+      available_memory_kb > total_memory_kb)
+    return false;
+
+  unsigned long long total_memory = total_memory_kb * 1024;
+  unsigned long long free_memory = available_memory_kb * 1024;
+  unsigned long long used_memory = total_memory - free_memory;
+
+  SET_GPUINFO_DYNAMIC(dynamic_info, total_memory, total_memory);
+  SET_GPUINFO_DYNAMIC(dynamic_info, free_memory, free_memory);
+  SET_GPUINFO_DYNAMIC(dynamic_info, used_memory, used_memory);
+  SET_GPUINFO_DYNAMIC(dynamic_info, mem_util_rate, used_memory * 100 / total_memory);
+
+  return true;
+}
+
 // Processes GPU Utilization
 
 typedef struct {
@@ -654,28 +694,11 @@ static void gpuinfo_nvidia_refresh_dynamic_info(struct gpu_info *_gpu_info) {
     }
   }
 
-  // Handle unified memory GPUs - query system memory
+  // Handle unified memory GPUs. On UMA platforms such as DGX Spark, NVML does
+  // not expose dedicated framebuffer memory, so use the Linux system memory
+  // counters recommended by NVIDIA for memory reporting.
   if (has_unified_memory) {
-    // Read MemAvailable from /proc/meminfo for available memory
-    FILE *meminfo = fopen("/proc/meminfo", "r");
-    if (meminfo) {
-      unsigned long long total_memory = 0;
-      char line[256];
-
-      while (fgets(line, sizeof(line), meminfo)) {
-        if (sscanf(line, "MemTotal: %llu kB", &total_memory) == 1) {
-          total_memory *= 1024; // Convert KB to bytes
-          break;
-        }
-      }
-      fclose(meminfo);
-
-      // The used memory will be computed from process infos as part of the
-      // fixup function gpuinfo_fix_dynamic_info_from_process_info from
-      // extract_gpuinfo.c
-      if (total_memory > 0)
-        SET_GPUINFO_DYNAMIC(dynamic_info, total_memory, total_memory);
-    }
+    set_unified_system_memory_info(dynamic_info);
   }
 
   // Pcie generation used by the device


### PR DESCRIPTION
## Summary

This PR improves NVIDIA UMA/iGPU memory reporting for platforms where NVML does not expose dedicated framebuffer memory. On these systems NVML can return `NVML_ERROR_NOT_SUPPORTED` for `nvmlDeviceGetMemoryInfo*()` because the GPU shares system memory instead of having a dedicated framebuffer.

The concrete hardware used to reproduce and validate this change is:

- NVIDIA DGX Spark
- GPU: NVIDIA GB10
- Driver: 580.142
- CUDA: 13.0
- Architecture: unified memory / iGPU-style platform

## Problem

On DGX Spark / GB10, `nvidia-smi` reports framebuffer memory as unsupported:

```text
FB Memory Usage
    Total : N/A
    Used  : N/A
    Free  : N/A
```

Before this change, nvtop detected the unified-memory case but only populated `total_memory` from `/proc/meminfo`. As a result, the UI still had incomplete memory reporting and the overall memory meter could not show the available/used UMA memory state.

## Changes

- Add a small NVIDIA backend fallback that reads `/proc/meminfo` when NVML reports unified memory / unsupported framebuffer memory.
- Populate:
  - `total_memory` from `MemTotal`
  - `free_memory` from `MemAvailable`
  - `used_memory` as `MemTotal - MemAvailable`
  - `mem_util_rate` from the same values
- Fix the generic process-memory fallback accumulation bug where `used_memory` was added to itself before adding each process usage.

This keeps the change scoped to the existing UMA path and does not alter normal discrete NVIDIA GPU memory reporting.

## Validation

Built and tested on the DGX Spark / GB10 machine:

```text
build/src/nvtop: ELF 64-bit LSB pie executable, ARM aarch64
nvtop version 3.3.2
```

`nvtop --snapshot` after the change:

```text
"device_name": "NVIDIA GB10"
"mem_util": "10%"
"mem_total": "130595311616"
"mem_used": "13716254720"
"mem_free": "116879056896"
```

Interactive UI was also tested on the DGX Spark desktop session. The memory meter changed from `N/A` to a UMA system memory value, for example:

```text
13.045Gi/121.626Gi
```

Local build validation was also run on an x86_64 NVIDIA system with discrete RTX 3060 GPUs to ensure the normal NVML framebuffer path still builds and reports discrete GPU memory through NVML.

## Not addressed / expected remaining N/A fields

This PR intentionally does not attempt to synthesize metrics that NVML and `nvidia-smi` still do not expose on DGX Spark / GB10. On the tested machine these remain `N/A` in `nvidia-smi` as well:

```text
Fan Speed              : N/A
Tx Throughput          : N/A
Rx Throughput          : N/A
Memory Clock           : N/A
Power Limit            : N/A
```

Those are left unchanged because they require driver/platform telemetry support or another documented data source. This PR only addresses the UMA memory reporting case where NVIDIA documentation recommends estimating memory resources from Linux system memory counters rather than relying on framebuffer memory.
