### PR TITLE
fix: add missing delwin() calls in free_device_windows

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -202,6 +202,9 @@ static void free_device_windows(struct device_window *dwin) {
   delwin(dwin->temperature);
   delwin(dwin->fan_speed);
   delwin(dwin->pcie_info);
+  delwin(dwin->shader_cores);
+  delwin(dwin->l2_cache_size);
+  delwin(dwin->exec_engines);
 }
 
 static void alloc_process_with_option(struct nvtop_interface *interface, unsigned posX, unsigned posY, unsigned sizeX,


### PR DESCRIPTION
`shader_cores`, `l2_cache_size`, and `exec_engines` were allocated with `newwin()` in `alloc_device_window()` but never freed in `free_device_windows()`. This caused a memory leak every time device windows were torn down (e.g. on refresh or hot-unplug).

The function now frees all windows it allocates, preventing resource leaks in long-running sessions.