### PR TITLE
fix: free plot_window in delete_all_windows

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -397,6 +397,7 @@ static void delete_all_windows(struct nvtop_interface *dwin) {
   delwin(dwin->process.option_window.option_win);
   for (size_t i = 0; i < dwin->num_plots; ++i) {
     delwin(dwin->plots[i].win);
+    delwin(dwin->plots[i].plot_window);
     free(dwin->plots[i].data);
   }
   free_setup_window(&dwin->setup_win);


### PR DESCRIPTION
`initialize_gpu_mem_plot()` allocates `plot->plot_window` with `newwin()` but `delete_all_windows()` only calls `delwin()` on `plots[i].win`, leaking the `plot_window`. This leaks one `WINDOW` struct per chart on every resize (Ctrl+L) or monitored-GPU-set change that triggers `delete_all_windows()` followed by `initialize_all_windows()`.

Apologies for 2 PR's. Found #467 while working in the "extra GPU info bar", then ran an audit for other leaks after and found `plot_window`. 🙏