### PR TITLE
fix: correctly check nvidia MIG mode status for process utilization

### DIFF
--- a/src/extract_gpuinfo_nvidia.c
+++ b/src/extract_gpuinfo_nvidia.c
@@ -933,6 +933,6 @@ static void gpuinfo_nvidia_get_running_processes(struct gpu_info *_gpu_info) {
   }
   // If the GPU is in MIG mode; process utilization is not supported
   if (!(IS_VALID(gpuinfo_multi_instance_mode_valid, gpu_info->base.dynamic_info.valid) &&
-        !gpu_info->base.dynamic_info.multi_instance_mode))
+        gpu_info->base.dynamic_info.multi_instance_mode))
     gpuinfo_nvidia_get_process_utilization(gpu_info, _gpu_info->processes_count, _gpu_info->processes);
 }


### PR DESCRIPTION
On common GPUs, like RTX:

```text
$ nvidia-smi --query-gpu=mig.mode.current
mig.mode.current
[N/A]
```

Process utilization OK

On A100:

```text
$ nvidia-smi --query-gpu=mig.mode.current
mig.mode.current
Disabled
Disabled
...
```

But no process utilization available
![screenshot](https://github.com/user-attachments/assets/1ecc1733-563b-4d7b-94cf-93ea5de73d12)


This PR should bring process utilization back when MIG disabled