### PR TITLE
Fix: correctly use hide-processes option from config file

### DIFF
--- a/src/nvtop.c
+++ b/src/nvtop.c
@@ -294,7 +294,8 @@ int main(int argc, char **argv) {
       allDevicesOptions.gpu_specific_opts[i].to_draw = 0;
     }
   }
-  allDevicesOptions.hide_processes_list = hide_processes_option;
+  if (hide_processes_option)
+    allDevicesOptions.hide_processes_list = true;
   if (encode_decode_timer_option_set) {
     allDevicesOptions.encode_decode_hiding_timer = encode_decode_hide_time;
     if (allDevicesOptions.encode_decode_hiding_timer < 0.)


### PR DESCRIPTION
This reverts commit 941a579.
Fixes #416. The option value read from the config file was being overwritten by the default value.