### PR TITLE
Fix udev enumerator leaks and a wrong null-check in device discovery

### DIFF
--- a/src/device_discovery_linux.c
+++ b/src/device_discovery_linux.c
@@ -97,7 +97,7 @@ int nvtop_device_get_syspath(nvtop_device *device, const char **sysPath) {
 
 int nvtop_enumerator_new(nvtop_device_enumerator **enumerator) {
   *enumerator = calloc(1, sizeof(**enumerator));
-  if (!enumerator)
+  if (!*enumerator)
     return -1;
   (*enumerator)->refCount = 1;
   (*enumerator)->udev = udev_new();
@@ -342,16 +342,18 @@ nvtop_device *nvtop_device_get_hwmon(nvtop_device *dev) {
   int ret = nvtop_enumerator_new(&enumerator);
   if (ret < 0)
     return NULL;
+  nvtop_device *hwmon = NULL;
   ret = nvtop_device_enumerator_add_match_subsystem(enumerator, "hwmon", true);
   if (ret < 0)
-    return NULL;
+    goto out;
   ret = nvtop_device_enumerator_add_match_parent(enumerator, dev);
   if (ret < 0)
-    return NULL;
-  nvtop_device *hwmon = nvtop_enumerator_get_device_first(enumerator);
+    goto out;
+  hwmon = nvtop_enumerator_get_device_first(enumerator);
   if (!hwmon)
-    return NULL;
+    goto out;
   nvtop_device_ref(hwmon);
+out:
   nvtop_enumerator_unref(enumerator);
   return hwmon;
 }

--- a/src/extract_gpuinfo_intel.c
+++ b/src/extract_gpuinfo_intel.c
@@ -130,13 +130,14 @@ bool gpuinfo_intel_get_device_handles(struct list_head *devices_list, unsigned *
   if (nvtop_enumerator_new(&enumerator) < 0)
     return false;
 
+  bool ret = false;
+  unsigned num_devices = 0;
   if (nvtop_device_enumerator_add_match_subsystem(enumerator, "drm", true) < 0)
-    return false;
+    goto out;
 
   if (nvtop_device_enumerator_add_match_property(enumerator, "DEVNAME", "/dev/dri/*") < 0)
-    return false;
+    goto out;
 
-  unsigned num_devices = 0;
   for (nvtop_device *device = nvtop_enumerator_get_device_first(enumerator); device;
        device = nvtop_enumerator_get_device_next(enumerator)) {
     num_devices++;
@@ -144,7 +145,7 @@ bool gpuinfo_intel_get_device_handles(struct list_head *devices_list, unsigned *
 
   gpu_infos = calloc(num_devices, sizeof(*gpu_infos));
   if (!gpu_infos)
-    return false;
+    goto out;
 
   for (nvtop_device *device = nvtop_enumerator_get_device_first(enumerator); device;
        device = nvtop_enumerator_get_device_next(enumerator)) {
@@ -157,8 +158,10 @@ bool gpuinfo_intel_get_device_handles(struct list_head *devices_list, unsigned *
     }
   }
 
+  ret = true;
+out:
   nvtop_enumerator_unref(enumerator);
-  return true;
+  return ret;
 }
 
 void gpuinfo_intel_populate_static_info(struct gpu_info *_gpu_info) {

--- a/src/extract_gpuinfo_v3d.c
+++ b/src/extract_gpuinfo_v3d.c
@@ -220,13 +220,14 @@ bool gpuinfo_v3d_get_device_handles(struct list_head *devices_list, unsigned *co
   if (nvtop_enumerator_new(&enumerator) < 0)
     return false;
 
+  bool ret = false;
+  unsigned num_devices = 0;
   if (nvtop_device_enumerator_add_match_subsystem(enumerator, "drm", true) < 0)
-    return false;
+    goto out;
 
   if (nvtop_device_enumerator_add_match_property(enumerator, "DEVNAME", "/dev/dri/*") < 0)
-    return false;
+    goto out;
 
-  unsigned num_devices = 0;
   for (nvtop_device *device = nvtop_enumerator_get_device_first(enumerator); device;
        device = nvtop_enumerator_get_device_next(enumerator)) {
     num_devices++;
@@ -234,7 +235,7 @@ bool gpuinfo_v3d_get_device_handles(struct list_head *devices_list, unsigned *co
 
   gpu_infos = calloc(num_devices, sizeof(*gpu_infos));
   if (!gpu_infos)
-    return false;
+    goto out;
 
   for (nvtop_device *device = nvtop_enumerator_get_device_first(enumerator); device;
        device = nvtop_enumerator_get_device_next(enumerator)) {
@@ -247,8 +248,10 @@ bool gpuinfo_v3d_get_device_handles(struct list_head *devices_list, unsigned *co
     }
   }
 
+  ret = true;
+out:
   nvtop_enumerator_unref(enumerator);
-  return true;
+  return ret;
 }
 
 void gpuinfo_v3d_populate_static_info(struct gpu_info *_gpu_info) {


### PR DESCRIPTION
While reading the udev device-discovery code I noticed the enumerator is
leaked on a few early-return paths, in the same spirit as the recent cleanup
fixes (#467, #468).

Three functions create an enumerator with `nvtop_enumerator_new()` and then
return early when a match/alloc step fails, without calling
`nvtop_enumerator_unref()`: `nvtop_device_get_hwmon()` and the intel/v3d
`gpuinfo_*_get_device_handles()`. The leaked enumerator owns a udev handle and
a udev_enumerate object. The no-hwmon branch in `nvtop_device_get_hwmon()` runs
for every device that has no hwmon node, so this one leaks on a normal run
rather than only on failure. I routed the early exits through a single unref
with the goto-cleanup pattern already used in `nvtop_enumerator_new()`, leaving
the success path unchanged.

The same commit also fixes `nvtop_enumerator_new()`: it checked `enumerator`
(the address of the caller's variable, never NULL) instead of `*enumerator`
(the calloc result), so an out-of-memory calloc would dereference NULL instead
of returning -1.

Validated on x86_64 (all backends + libdrm) and arm64 (NVIDIA + v3d): clean
build with `-Wall -Wextra`, the gtest suite passes, and `--snapshot` on a live
GPU still enumerates devices and reports stats. I also confirmed the leak with
LeakSanitizer on both arches: a build that skips the unref on the early-return
path leaks the enumerator (the udev handle and udev_enumerate object), and the
fix brings it to zero. clang's static analyzer flags the leak in
`nvtop_device_get_hwmon()` before the change and is clean after.
