### PR TITLE
Avoid division by zero and clock overflow in utilisation rate

### DIFF
--- a/src/extract_gpuinfo.c
+++ b/src/extract_gpuinfo.c
@@ -399,7 +399,12 @@ void gpuinfo_refresh_utilisation_rate(struct gpu_info *gpu_info) {
           ec = 1;
 
   avg_delta_secs = ((double)total_delta / gpu_info->processes_count) / 1000000000.0;
-  max_freq_hz = gpu_info->dynamic_info.gpu_clock_speed_max * 1000000;
+  max_freq_hz = (uint64_t)gpu_info->dynamic_info.gpu_clock_speed_max * 1000000;
+  // Without a known maximum frequency or a positive time delta the utilisation
+  // cannot be derived; bail out instead of dividing by zero (which yields an
+  // infinite rate and undefined behaviour when cast to unsigned).
+  if (max_freq_hz == 0 || avg_delta_secs == 0.0 || ec == 0)
+    return;
   utilisation_rate = (unsigned int)((((double)gfx_total_process_cycles) / (((double)max_freq_hz) * avg_delta_secs * ec)) * 100);
   utilisation_rate = utilisation_rate > 100 ? 100 : utilisation_rate;
 


### PR DESCRIPTION
`gpuinfo_refresh_utilisation_rate()` derives GPU utilisation from
drm-cycles and drm-maxfreq, and is used by the panfrost and panthor
backends. There are two problems in the same computation.

When the fdinfo has no drm-maxfreq key, `gpu_clock_speed_max` stays 0, so
`max_freq_hz` is 0 and the utilisation division has a zero denominator.
The double division yields infinity and the subsequent cast to
`unsigned int` is undefined behaviour. A zero sample delta or a reported
`engine_count` of 0 hit the same zero denominator. The fix returns early
when the denominator would be zero, which leaves `gpu_util_rate` unset so
the UI reports N/A rather than a bogus value, matching the existing
`if (!gfx_total_process_cycles) return;` guard above it.

`gpu_clock_speed_max` is an `unsigned int` in MHz; multiplying by 1000000
in `unsigned int` arithmetic overflows above ~4295 MHz before the result
is stored in the `uint64_t max_freq_hz`. Casting to `uint64_t` first keeps
the frequency correct (a 5000 MHz clock gave 705032704 Hz before, and
5000000000 Hz after).

Validation: under UBSan, the zero-frequency case reported
`extract_gpuinfo.c: runtime error: division by zero` before the guard and
returns cleanly after; a 5000 MHz clock with 2.5e9 cycles over 1 s now
yields 50% (it clamped to 100% before the cast). Built clean on x86_64
(all backends) and arm64, and the gtest suite passes.
