### PR TITLE
fix: increase buffer size for elapsed time on timeline

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -255,65 +255,65 @@ static void initialize_gpu_mem_plot(struct plot_window *plot, struct window_posi
     column_divisor += plot_count_draw_info(to_draw);
   }
   assert(column_divisor > 0);
-  char elapsedSeconds[5];
+  char elapsedSeconds[16];
   char *err = "err";
   char *zeroSec = "0s";
   if (options->plot_left_to_right) {
     char *toPrint = zeroSec;
     mvwprintw(plot->win, position->sizeY - 1, 4, "%s", toPrint);
 
-    int retval = snprintf(elapsedSeconds, 5, "%ds", options->update_interval * cols / 4 / column_divisor / 1000);
-    if (retval > 4)
-      toPrint = err;
-    else
-      toPrint = elapsedSeconds;
+     int retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds", options->update_interval * cols / 4 / column_divisor / 1000);
+     if (retval >= (int)sizeof(elapsedSeconds))
+       toPrint = err;
+     else
+       toPrint = elapsedSeconds;
     mvwprintw(plot->win, position->sizeY - 1, 4 + cols / 4 - strlen(toPrint) / 2, "%s", toPrint);
 
-    retval = snprintf(elapsedSeconds, 5, "%ds", options->update_interval * cols / 2 / column_divisor / 1000);
-    if (retval > 4)
+    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds", options->update_interval * cols / 2 / column_divisor / 1000);
+    if (retval >= (int)sizeof(elapsedSeconds))
       toPrint = err;
     else
       toPrint = elapsedSeconds;
     mvwprintw(plot->win, position->sizeY - 1, 4 + cols / 2 - strlen(toPrint) / 2, "%s", toPrint);
 
-    retval = snprintf(elapsedSeconds, 5, "%ds", options->update_interval * cols * 3 / 4 / column_divisor / 1000);
-    if (retval > 4)
+    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds", options->update_interval * cols * 3 / 4 / column_divisor / 1000);
+    if (retval >= (int)sizeof(elapsedSeconds))
       toPrint = err;
     else
       toPrint = elapsedSeconds;
     mvwprintw(plot->win, position->sizeY - 1, 4 + cols * 3 / 4 - strlen(toPrint) / 2, "%s", toPrint);
 
-    retval = snprintf(elapsedSeconds, 5, "%ds", options->update_interval * cols / column_divisor / 1000);
-    if (retval > 4)
+    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds", options->update_interval * cols / column_divisor / 1000);
+    if (retval >= (int)sizeof(elapsedSeconds))
       toPrint = err;
     else
       toPrint = elapsedSeconds;
     mvwprintw(plot->win, position->sizeY - 1, 4 + cols - strlen(toPrint), "%s", toPrint);
   } else {
     char *toPrint;
-    int retval = snprintf(elapsedSeconds, 5, "%ds", options->update_interval * cols / column_divisor / 1000);
-    if (retval > 4)
+    int retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds", options->update_interval * cols / column_divisor / 1000);
+    if (retval >= (int)sizeof(elapsedSeconds))
       toPrint = err;
     else
       toPrint = elapsedSeconds;
     mvwprintw(plot->win, position->sizeY - 1, 4, "%s", toPrint);
 
-    retval = snprintf(elapsedSeconds, 5, "%ds", options->update_interval * cols * 3 / 4 / column_divisor / 1000);
-    if (retval > 4)
+    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds", options->update_interval * cols * 3 / 4 / column_divisor / 1000);
+    if (retval >= (int)sizeof(elapsedSeconds))
       toPrint = err;
     else
       toPrint = elapsedSeconds;
     mvwprintw(plot->win, position->sizeY - 1, 4 + cols / 4 - strlen(toPrint) / 2, "%s", toPrint);
 
-    retval = snprintf(elapsedSeconds, 5, "%ds", options->update_interval * cols / 2 / column_divisor / 1000);
-    if (retval > 4)
+    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds", options->update_interval * cols / 2 / column_divisor / 1000);
+    if (retval >= (int)sizeof(elapsedSeconds))
       toPrint = err;
     else
       toPrint = elapsedSeconds;
     mvwprintw(plot->win, position->sizeY - 1, 4 + cols / 2 - strlen(toPrint) / 2, "%s", toPrint);
 
-    retval = snprintf(elapsedSeconds, 5, "%ds", options->update_interval * cols / 4 / column_divisor / 1000);
-    if (retval > 4)
+    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds", options->update_interval * cols / 4 / column_divisor / 1000);
+    if (retval >= (int)sizeof(elapsedSeconds))
       toPrint = err;
     else
       toPrint = elapsedSeconds;

--- a/src/interface.c
+++ b/src/interface.c
@@ -262,28 +262,32 @@ static void initialize_gpu_mem_plot(struct plot_window *plot, struct window_posi
     char *toPrint = zeroSec;
     mvwprintw(plot->win, position->sizeY - 1, 4, "%s", toPrint);
 
-     int retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds", options->update_interval * cols / 4 / column_divisor / 1000);
-     if (retval >= (int)sizeof(elapsedSeconds))
-       toPrint = err;
-     else
-       toPrint = elapsedSeconds;
+    int retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds",
+                          options->update_interval * cols / 4 / column_divisor / 1000);
+    if (retval >= (int)sizeof(elapsedSeconds))
+      toPrint = err;
+    else
+      toPrint = elapsedSeconds;
     mvwprintw(plot->win, position->sizeY - 1, 4 + cols / 4 - strlen(toPrint) / 2, "%s", toPrint);
 
-    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds", options->update_interval * cols / 2 / column_divisor / 1000);
+    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds",
+                      options->update_interval * cols / 2 / column_divisor / 1000);
     if (retval >= (int)sizeof(elapsedSeconds))
       toPrint = err;
     else
       toPrint = elapsedSeconds;
     mvwprintw(plot->win, position->sizeY - 1, 4 + cols / 2 - strlen(toPrint) / 2, "%s", toPrint);
 
-    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds", options->update_interval * cols * 3 / 4 / column_divisor / 1000);
+    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds",
+                      options->update_interval * cols * 3 / 4 / column_divisor / 1000);
     if (retval >= (int)sizeof(elapsedSeconds))
       toPrint = err;
     else
       toPrint = elapsedSeconds;
     mvwprintw(plot->win, position->sizeY - 1, 4 + cols * 3 / 4 - strlen(toPrint) / 2, "%s", toPrint);
 
-    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds", options->update_interval * cols / column_divisor / 1000);
+    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds",
+                      options->update_interval * cols / column_divisor / 1000);
     if (retval >= (int)sizeof(elapsedSeconds))
       toPrint = err;
     else
@@ -291,28 +295,32 @@ static void initialize_gpu_mem_plot(struct plot_window *plot, struct window_posi
     mvwprintw(plot->win, position->sizeY - 1, 4 + cols - strlen(toPrint), "%s", toPrint);
   } else {
     char *toPrint;
-    int retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds", options->update_interval * cols / column_divisor / 1000);
+    int retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds",
+                          options->update_interval * cols / column_divisor / 1000);
     if (retval >= (int)sizeof(elapsedSeconds))
       toPrint = err;
     else
       toPrint = elapsedSeconds;
     mvwprintw(plot->win, position->sizeY - 1, 4, "%s", toPrint);
 
-    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds", options->update_interval * cols * 3 / 4 / column_divisor / 1000);
+    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds",
+                      options->update_interval * cols * 3 / 4 / column_divisor / 1000);
     if (retval >= (int)sizeof(elapsedSeconds))
       toPrint = err;
     else
       toPrint = elapsedSeconds;
     mvwprintw(plot->win, position->sizeY - 1, 4 + cols / 4 - strlen(toPrint) / 2, "%s", toPrint);
 
-    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds", options->update_interval * cols / 2 / column_divisor / 1000);
+    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds",
+                      options->update_interval * cols / 2 / column_divisor / 1000);
     if (retval >= (int)sizeof(elapsedSeconds))
       toPrint = err;
     else
       toPrint = elapsedSeconds;
     mvwprintw(plot->win, position->sizeY - 1, 4 + cols / 2 - strlen(toPrint) / 2, "%s", toPrint);
 
-    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds", options->update_interval * cols / 4 / column_divisor / 1000);
+    retval = snprintf(elapsedSeconds, sizeof(elapsedSeconds), "%ds",
+                      options->update_interval * cols / 4 / column_divisor / 1000);
     if (retval >= (int)sizeof(elapsedSeconds))
       toPrint = err;
     else


### PR DESCRIPTION
# Description

This pull request fixes a bug in the `nvtop` timeline where the elapsed time would erroneously display as `err` when the terminal width was large and the update delay was significant.

## Problem

When running `nvtop` in a wide terminal with a large update delay, the timeline would sometimes show `err` instead of the actual elapsed time (e.g., `1234s`). 

This occurred because the buffer used to format the elapsed time string was too small. When the number of seconds exceeded the capacity of the buffer, `snprintf` would return a value indicating truncation, which the code interpreted as an error, triggering the fallback to the `"err"` string.

## Root Cause

In `src/interface.c`, the buffer for the elapsed time string was defined with a hardcoded size of 5:

```c
char elapsedSeconds[5];
```

As the application ran longer, the number of seconds would eventually require more than 4 characters (plus the null terminator). For example, "100s" is 4 characters, and "1000s" is 5 characters. When `snprintf` attempted to write a string longer than the buffer, it returned a value $\ge 5$, which matched the following error check:

```c
if (retval > 4)
  toPrint = err;
```

## Fix

The fix involves three key changes in `src/interface.c`:

1. **Increased Buffer Size**: Expanded the `elapsedSeconds` buffer from `5` to `16` characters to safely accommodate much longer time durations.
2. **Robust Length Checking**: Updated the `snprintf` return value check to use `sizeof(elapsedSeconds)` instead of the hardcoded `4`. This ensures that the error handling logic scales correctly with the buffer size.
3. **Type Safety**: Added an explicit cast to `(int)` for the `sizeof` comparison to avoid signed/unsigned comparison warnings.

## Verification Results

The fix was verified using the following steps:

1. **Reproduction**: A test was conducted by setting a large terminal width and a significant update delay, then checking the output for the error string using the following command:

   ```bash
   (export COLUMNS=320; printf '\033[21~' | nvtop --no-color) | strings -n 3 | grep -E 'err|[0-9]{2,}s$'
   ```

   The command successfully detected the `"err"` string in the output, reproducing the bug.

2. **Build**: The `nvtop` binary was rebuilt from source.

3. **Validation**: The same test command was re-run. The command no longer detected `"err"` and instead confirmed that the output contains valid elapsed time strings (e.g., `1570s`). The test was repeated with increasingly large values of delay - including the max value of 99.9 seconds that is settable from the UI (`UpdateInterval = 99900` in `~/.config/nvtop/interface.ini`) and even larger values set directly in the config file (up to 86400 seconds, which corresponds to a full day long update interval).