### PR TITLE
Show peak PCIe RX/TX throughput in the device header

### DIFF
--- a/include/nvtop/interface_internal_common.h
+++ b/include/nvtop/interface_internal_common.h
@@ -73,6 +73,8 @@ struct device_window {
   WINDOW *shader_cores;
   WINDOW *l2_cache_size;
   WINDOW *exec_engines;
+  unsigned pcie_rx_peak; // Peak PCIe RX throughput observed since launch (KB/s)
+  unsigned pcie_tx_peak; // Peak PCIe TX throughput observed since launch (KB/s)
   bool enc_was_visible;
   bool dec_was_visible;
   nvtop_time last_decode_seen;

--- a/src/interface.c
+++ b/src/interface.c
@@ -44,7 +44,7 @@
 
 static unsigned int sizeof_device_field[device_field_count] = {
     [device_name] = 11,       [device_fan_speed] = 11,   [device_temperature] = 10, [device_power] = 15,
-    [device_clock] = 11,      [device_mem_clock] = 12,   [device_pcie] = 46,        [device_shadercores] = 7,
+    [device_clock] = 11,      [device_mem_clock] = 12,   [device_pcie] = 88,        [device_shadercores] = 7,
     [device_l2features] = 11, [device_execengines] = 11,
 };
 
@@ -575,6 +575,29 @@ static void print_pcie_at_scale(WINDOW *win, unsigned int value) {
   wprintw(win, " %sB/s", memory_prefix[prefix_off]);
 }
 
+// Print a labelled PCIe throughput field as "<label><current> (max <peak>)", updating
+// *peak with the running maximum. Prints "<label>N/A" when the value is not available.
+static void print_pcie_throughput_with_peak(WINDOW *win, const char *label, bool valid, unsigned value,
+                                            unsigned *peak) {
+  wcolor_set(win, magenta_color, NULL);
+  wprintw(win, "%s", label);
+  wstandend(win);
+  if (!valid) {
+    wprintw(win, "N/A");
+    return;
+  }
+  if (value > *peak)
+    *peak = value;
+  print_pcie_at_scale(win, value);
+  wcolor_set(win, magenta_color, NULL);
+  wprintw(win, " (max ");
+  wstandend(win);
+  print_pcie_at_scale(win, *peak);
+  wcolor_set(win, magenta_color, NULL);
+  wprintw(win, ")");
+  wstandend(win);
+}
+
 static inline void werase_and_wnoutrefresh(WINDOW *w) {
   werase(w);
   wnoutrefresh(w);
@@ -848,20 +871,12 @@ static void draw_devices(struct list_head *devices, struct nvtop_interface *inte
         wprintw(dev->pcie_info, "N/A");
     }
 
-    wcolor_set(dev->pcie_info, magenta_color, NULL);
-    wprintw(dev->pcie_info, " RX: ");
-    wstandend(dev->pcie_info);
-    if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, pcie_rx))
-      print_pcie_at_scale(dev->pcie_info, device->dynamic_info.pcie_rx);
-    else
-      wprintw(dev->pcie_info, "N/A");
-    wcolor_set(dev->pcie_info, magenta_color, NULL);
-    wprintw(dev->pcie_info, " TX: ");
-    wstandend(dev->pcie_info);
-    if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, pcie_tx))
-      print_pcie_at_scale(dev->pcie_info, device->dynamic_info.pcie_tx);
-    else
-      wprintw(dev->pcie_info, "N/A");
+    print_pcie_throughput_with_peak(dev->pcie_info, " RX: ",
+                                    GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, pcie_rx),
+                                    device->dynamic_info.pcie_rx, &dev->pcie_rx_peak);
+    print_pcie_throughput_with_peak(dev->pcie_info, " TX: ",
+                                    GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, pcie_tx),
+                                    device->dynamic_info.pcie_tx, &dev->pcie_tx_peak);
 
     wnoutrefresh(dev->pcie_info);
 


### PR DESCRIPTION
## Summary

Tracks the maximum PCIe RX and TX throughput observed since launch and displays it next to the instantaneous values in the device header:

```
PCIe GEN 5@16x RX: 1.2 GiB/s (max 57.5 GiB/s) TX: 48.3 MiB/s (max 59.8 GiB/s)
```

This makes transient transfer peaks visible at a glance when diagnosing bus bottlenecks, without having to watch the live value.

- Adds `pcie_rx_peak` / `pcie_tx_peak` to `struct device_window` (zero-initialized via the existing `calloc`; they persist across terminal resize since the struct isn't reallocated).
- The RX/TX rendering is refactored into a single `print_pcie_throughput_with_peak()` helper used for both directions (removes the prior copy-paste).
- The peak resets only when nvtop restarts.

### Note: header width
The PCIe header field is widened (46 → 88 columns) to fit the extra value, which increases each device panel's width. On a single wide terminal this is fine; on narrow or dense multi-GPU layouts it reduces how many panels fit per row. This is why the change is split out from the chart feature (#268 / the companion PR). Happy to make it opt-in via a config toggle if preferred.

Made with [Cursor](https://cursor.com)