### PR TITLE
docs: mention invalid TERM ncurses error 

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -422,6 +422,7 @@ Troubleshoot
 
 - The plot looks bad:
   - Verify that you installed the wide character version of the ncurses library (libncurses**w**5-dev for Debian / Ubuntu), clean the build directory and restart the build process.
+- If `nvtop` exits with `ncurses: cannot initialize terminal type ($TERM="unknown")`, ensure that `$TERM` is set to a valid terminal type such as `xterm-256color`.
 - **Putty**: Tell putty not to lie about its capabilities (`$TERM`) by setting the field ``Terminal-type string`` to ``putty`` in the menu
   ``Connection > Data > Terminal Details``.
 - `NO GPU to monitor.` for NVIDIA GPUs:


### PR DESCRIPTION
What changed:
- Added a troubleshooting note for ncurses failures when $TERM is unset or invalid.

Why:
- nvtop may exit with "ncurses: cannot initialize terminal type" in sandboxed or minimal terminals when $TERM is unset or invalid.
- Setting $TERM to a valid terminal type, such as xterm-256color, resolves this.

Testing:
- Built nvtop locally on Fedora 44.
- Verified the error occurred with TERM=unknown and was resolved with TERM=xterm-256color locally.