### PR TITLE
amdgpu: count GTT in per-process memory usage

### DIFF
--- a/src/extract_gpuinfo_amdgpu.c
+++ b/src/extract_gpuinfo_amdgpu.c
@@ -786,6 +786,8 @@ static void gpuinfo_amdgpu_refresh_dynamic_info(struct gpu_info *_gpu_info) {
 static const char drm_amdgpu_pdev_old[] = "pdev";
 static const char drm_amdgpu_vram_old[] = "vram mem";
 static const char drm_amdgpu_vram[] = "drm-memory-vram";
+static const char drm_amdgpu_gtt_old[] = "gtt mem";
+static const char drm_amdgpu_gtt[] = "drm-memory-gtt";
 static const char drm_amdgpu_gfx_old[] = "gfx";
 static const char drm_amdgpu_gfx[] = "drm-engine-gfx";
 static const char drm_amdgpu_compute_old[] = "compute";
@@ -831,8 +833,12 @@ static bool parse_drm_fdinfo_amd(struct gpu_info *info, FILE *fdinfo_file, struc
       if (*endptr)
         continue;
       client_id_set = true;
-    } else if (!strcmp(key, drm_amdgpu_vram_old) || !strcmp(key, drm_amdgpu_vram)) {
-      // TODO: do we count "gtt mem" too?
+    } else if (!strcmp(key, drm_amdgpu_vram_old) || !strcmp(key, drm_amdgpu_vram) ||
+               !strcmp(key, drm_amdgpu_gtt_old) || !strcmp(key, drm_amdgpu_gtt)) {
+      // Count VRAM and GTT together, matching the device-level accounting
+      // which sums both heaps (amdgpu_query_info above). Integrated GPUs
+      // allocate almost everything in GTT, so counting only VRAM reports
+      // near-zero per-process memory there.
       unsigned long mem_int;
       char *endptr;
 
@@ -840,7 +846,7 @@ static bool parse_drm_fdinfo_amd(struct gpu_info *info, FILE *fdinfo_file, struc
       if (endptr == val || (strcmp(endptr, " kB") && strcmp(endptr, " KiB")))
         continue;
 
-      SET_GPUINFO_PROCESS(process_info, gpu_memory_usage, mem_int * 1024);
+      SET_GPUINFO_PROCESS(process_info, gpu_memory_usage, process_info->gpu_memory_usage + mem_int * 1024);
     } else {
       bool is_gfx_old = !strncmp(key, drm_amdgpu_gfx_old, sizeof(drm_amdgpu_gfx_old) - 1);
       bool is_compute_old = !strncmp(key, drm_amdgpu_compute_old, sizeof(drm_amdgpu_compute_old) - 1);


### PR DESCRIPTION
## Problem

Per-process memory on amdgpu only reads the `drm-memory-vram` fdinfo key.
On integrated GPUs, nearly all allocations live in the GTT heap, so the
process list reports ~0 memory while the device-level metrics show
gigabytes in use. This resolves the existing TODO at the parse site
(`// TODO: do we count "gtt mem" too?`).

Measured on a Ryzen AI 9 HX 370 / Radeon 890M (gfx1150, kernel 6.18),
with a 24 GB LLM loaded by ollama's llama-server:

    $ grep drm-memory /proc/<pid>/fdinfo/7
    drm-memory-cpu:         0 KiB
    drm-memory-gtt:  25258000 KiB   <- the model
    drm-memory-vram:     5348 KiB   <- all nvtop counted

nvtop showed the device at 24.3/48.0 GiB used, but attributed only
5 MiB to the process — and `gpu_mem_usage` read 0%.

## Change

Count `drm-memory-gtt` (and the legacy `gtt mem` key) together with
VRAM in `parse_drm_fdinfo_amd`, accumulating both into
`gpu_memory_usage`. This matches the device-level accounting, which
already sums both heaps via `amdgpu_query_info` (`total_memory` /
`used_memory` = vram + gtt). With numerator and denominator now
measuring the same thing, `gpu_mem_usage` percentages become coherent:
the process above reports 24.1 GiB / 50%, agreeing with the device
total.

## Behavior change on discrete GPUs

A process's reported memory now includes its GTT usage (host RAM mapped
for the GPU) on dGPUs as well. I'd argue this is consistent — the
device-level metric already includes GTT, and both heaps are GPU-mapped
memory — but if you'd prefer to keep dGPU semantics unchanged, I'm happy
to rework this to add GTT only when `static_info->integrated_graphics`
is set.

## Testing

Verified on the Radeon 890M above (before: ~0 per process; after:
per-process totals match device totals under a 24 GB workload).