### PR TITLE
Improve macOS GPU monitoring and telemetry

### DIFF
--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,4 +1,4 @@
-name: Compile Ubuntu
+name: Compile
 
 on:
   - push
@@ -38,3 +38,24 @@ jobs:
       with:
         name: nvtop ${{ matrix.os }}
         path: ${{ env.BUILD_DIR }}/install
+
+  build-macos:
+    runs-on: macos-latest
+
+    env:
+      BUILD_DIR: build
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: brew install googletest
+
+    - name: Configure CMake
+      run: cmake -S . -B $BUILD_DIR -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTING=ON -DCMAKE_PREFIX_PATH="$(brew --prefix googletest)"
+
+    - name: Build
+      run: cmake --build $BUILD_DIR --parallel
+
+    - name: Test
+      run: ctest --test-dir $BUILD_DIR --output-on-failure --no-tests=error

--- a/README.markdown
+++ b/README.markdown
@@ -133,6 +133,8 @@ NVTOP includes some initial support for Apple using Metal. This is only supporte
 
 **APPLE SUPPORT STATUS**
 - Apple support is still being worked on. Some bugs and limitations may apply.
+- On unified-memory systems, the memory meter compares global Metal resource allocations with total physical shared
+  memory. It does not represent dedicated VRAM or overall system memory pressure.
 
 ### Ascend
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,10 +116,12 @@ endif()
 if(APPLE_SUPPORT)
   target_sources(nvtop PRIVATE
     extract_gpuinfo_apple.m
+    extract_gpuinfo_apple_ioreport.c
     extract_gpuinfo_apple_utils.m)
   target_link_libraries(nvtop PRIVATE
     "-framework Metal"
     "-framework AppKit"
+    "-framework CoreFoundation"
     "-framework Foundation"
     "-framework QuartzCore"
     "-framework IOKit")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -46,6 +46,7 @@ if(UNIX AND NOT APPLE)
 elseif(APPLE)
   target_sources(nvtop PRIVATE
     get_process_info_mac.c
+    get_process_info_mac_utils.c
     extract_processinfo_mac.c
     info_messages_mac.c)
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,6 +117,7 @@ if(APPLE_SUPPORT)
   target_sources(nvtop PRIVATE
     extract_gpuinfo_apple.m
     extract_gpuinfo_apple_ioreport.c
+    extract_gpuinfo_apple_smc.c
     extract_gpuinfo_apple_utils.m)
   target_link_libraries(nvtop PRIVATE
     "-framework Metal"

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -113,7 +113,9 @@ if(V3D_SUPPORT)
 endif()
 
 if(APPLE_SUPPORT)
-  target_sources(nvtop PRIVATE extract_gpuinfo_apple.m)
+  target_sources(nvtop PRIVATE
+    extract_gpuinfo_apple.m
+    extract_gpuinfo_apple_utils.m)
   target_link_libraries(nvtop PRIVATE
     "-framework Metal"
     "-framework AppKit"

--- a/src/extract_gpuinfo_apple.m
+++ b/src/extract_gpuinfo_apple.m
@@ -198,6 +198,12 @@ static void gpuinfo_apple_refresh_dynamic_info(struct gpu_info *_gpu_info) {
   if (gpuinfo_apple_ioreport_get_power_draw(gpu_info->ioreport, &power_draw))
     SET_GPUINFO_DYNAMIC(dynamic_info, power_draw, power_draw);
 
+  unsigned clock_speed, max_clock_speed;
+  if (gpuinfo_apple_ioreport_get_gpu_clock_speed(gpu_info->ioreport, &clock_speed, &max_clock_speed)) {
+    SET_GPUINFO_DYNAMIC(dynamic_info, gpu_clock_speed, clock_speed);
+    SET_GPUINFO_DYNAMIC(dynamic_info, gpu_clock_speed_max, max_clock_speed);
+  }
+
   CFMutableDictionaryRef cf_props;
   if (IORegistryEntryCreateCFProperties(gpu_info->gpu_service, &cf_props, kCFAllocatorDefault, kNilOptions) != kIOReturnSuccess) {
     return;

--- a/src/extract_gpuinfo_apple.m
+++ b/src/extract_gpuinfo_apple.m
@@ -209,7 +209,8 @@ static void gpuinfo_apple_refresh_dynamic_info(struct gpu_info *_gpu_info) {
     if (sample.allocated_system_memory_valid)
       SET_GPUINFO_DYNAMIC(dynamic_info, used_memory, sample.allocated_system_memory);
 
-    // Memory is unified, so query the amount of system memory instead.
+    // Unified-memory GPUs share the system's physical memory with the CPU. The Metal
+    // recommendedMaxWorkingSetSize is a performance budget, not the memory capacity.
     mach_msg_type_number_t host_size = HOST_BASIC_INFO_COUNT;
     host_basic_info_data_t info;
     const mach_port_t host = mach_host_self();

--- a/src/extract_gpuinfo_apple.m
+++ b/src/extract_gpuinfo_apple.m
@@ -22,6 +22,7 @@
 #include "nvtop/extract_gpuinfo_common.h"
 #include "nvtop/time.h"
 #include "extract_gpuinfo_apple_ioreport.h"
+#include "extract_gpuinfo_apple_smc.h"
 #include "extract_gpuinfo_apple_utils.h"
 #include "uthash.h"
 
@@ -63,6 +64,7 @@ struct gpu_info_apple {
   id<MTLDevice> device;
   io_service_t gpu_service;
   struct gpuinfo_apple_ioreport *ioreport;
+  struct gpuinfo_apple_smc *smc;
   struct apple_process_info_cache *last_update_process_cache, *current_update_process_cache;
 };
 
@@ -117,6 +119,7 @@ static void gpuinfo_apple_shutdown(void) {
     gpuinfo_apple_free_process_cache(&gpu_info->last_update_process_cache);
     gpuinfo_apple_free_process_cache(&gpu_info->current_update_process_cache);
     gpuinfo_apple_ioreport_shutdown(gpu_info->ioreport);
+    gpuinfo_apple_smc_shutdown(gpu_info->smc);
     [gpu_info->device release];
     IOObjectRelease(gpu_info->gpu_service);
   }
@@ -161,8 +164,10 @@ static bool gpuinfo_apple_get_device_handles(struct list_head *devices, unsigned
     gpu_info->base.vendor = &gpu_vendor_apple;
     gpu_info->device = [dev retain];
     gpu_info->gpu_service = gpu_service;
-    if ([dev hasUnifiedMemory] && [dev location] == MTLDeviceLocationBuiltIn)
+    if ([dev hasUnifiedMemory] && [dev location] == MTLDeviceLocationBuiltIn) {
       gpuinfo_apple_ioreport_init(&gpu_info->ioreport);
+      gpuinfo_apple_smc_init(&gpu_info->smc);
+    }
     list_add_tail(&gpu_info->base.list, devices);
     ++apple_gpu_count;
   }
@@ -203,6 +208,10 @@ static void gpuinfo_apple_refresh_dynamic_info(struct gpu_info *_gpu_info) {
     SET_GPUINFO_DYNAMIC(dynamic_info, gpu_clock_speed, clock_speed);
     SET_GPUINFO_DYNAMIC(dynamic_info, gpu_clock_speed_max, max_clock_speed);
   }
+
+  unsigned temperature;
+  if (gpuinfo_apple_smc_get_gpu_temperature(gpu_info->smc, &temperature))
+    SET_GPUINFO_DYNAMIC(dynamic_info, gpu_temp, temperature);
 
   CFMutableDictionaryRef cf_props;
   if (IORegistryEntryCreateCFProperties(gpu_info->gpu_service, &cf_props, kCFAllocatorDefault, kNilOptions) != kIOReturnSuccess) {

--- a/src/extract_gpuinfo_apple.m
+++ b/src/extract_gpuinfo_apple.m
@@ -24,10 +24,12 @@
 #include "extract_gpuinfo_apple_utils.h"
 #include "uthash.h"
 
-#include <assert.h>
 #include <Metal/Metal.h>
 #include <IOKit/IOKitLib.h>
 #include <QuartzCore/QuartzCore.h>
+#include <mach/mach.h>
+#include <stdlib.h>
+#include <string.h>
 
 #define HASH_FIND_CLIENT(head, key_ptr, out_ptr)                                                                    \
   HASH_FIND(hh, head, key_ptr, sizeof(struct apple_process_cache_id), out_ptr)
@@ -127,20 +129,36 @@ static const char *gpuinfo_apple_last_error_string(void) {
 }
 
 static bool gpuinfo_apple_get_device_handles(struct list_head *devices, unsigned *count) {
+  *count = 0;
   NSArray<id<MTLDevice>> *mtl_devices = MTLCopyAllDevices();
+  if (!mtl_devices)
+    return false;
 
   const unsigned mtl_count = [mtl_devices count];
-  gpu_infos = calloc(mtl_count, sizeof(*gpu_infos));
+  if (mtl_count) {
+    gpu_infos = calloc(mtl_count, sizeof(*gpu_infos));
+    if (!gpu_infos) {
+      [mtl_devices release];
+      return false;
+    }
+  }
+
   for (unsigned int i = 0; i < mtl_count; ++i) {
     id<MTLDevice> dev = mtl_devices[i];
     const uint64_t registry_id = [dev registryID];
-    const io_service_t gpu_service = IOServiceGetMatchingService(kIOMainPortDefault, IORegistryEntryIDMatching(registry_id));
-    assert(MACH_PORT_VALID(gpu_service));
+    CFMutableDictionaryRef matching_service = IORegistryEntryIDMatching(registry_id);
+    if (!matching_service)
+      continue;
 
-    gpu_infos[apple_gpu_count].base.vendor = &gpu_vendor_apple;
-    gpu_infos[apple_gpu_count].device = dev;
-    gpu_infos[i].gpu_service = gpu_service;
-    list_add_tail(&gpu_infos[apple_gpu_count].base.list, devices);
+    const io_service_t gpu_service = IOServiceGetMatchingService(kIOMainPortDefault, matching_service);
+    if (!MACH_PORT_VALID(gpu_service))
+      continue;
+
+    struct gpu_info_apple *gpu_info = &gpu_infos[apple_gpu_count];
+    gpu_info->base.vendor = &gpu_vendor_apple;
+    gpu_info->device = [dev retain];
+    gpu_info->gpu_service = gpu_service;
+    list_add_tail(&gpu_info->base.list, devices);
     ++apple_gpu_count;
   }
 
@@ -156,8 +174,11 @@ static void gpuinfo_apple_populate_static_info(struct gpu_info *_gpu_info) {
   RESET_ALL(static_info->valid);
 
   const char *name = [[gpu_info->device name] UTF8String];
-  strncpy(static_info->device_name, name, sizeof(static_info->device_name));
-  SET_VALID(gpuinfo_device_name_valid, static_info->valid);
+  if (name) {
+    strncpy(static_info->device_name, name, sizeof(static_info->device_name) - 1);
+    static_info->device_name[sizeof(static_info->device_name) - 1] = '\0';
+    SET_VALID(gpuinfo_device_name_valid, static_info->valid);
+  }
 
   static_info->integrated_graphics = [gpu_info->device location] == MTLDeviceLocationBuiltIn;
   static_info->encode_decode_shared = true;
@@ -172,34 +193,30 @@ static void gpuinfo_apple_refresh_dynamic_info(struct gpu_info *_gpu_info) {
   if (IORegistryEntryCreateCFProperties(gpu_info->gpu_service, &cf_props, kCFAllocatorDefault, kNilOptions) != kIOReturnSuccess) {
     return;
   }
-  NSDictionary *props = (__bridge NSDictionary*) cf_props;
-  NSDictionary *performance_statistics = [props objectForKey:@"PerformanceStatistics"];
-  if (!performance_statistics) {
+  struct gpuinfo_apple_performance_sample sample;
+  const bool sample_valid = gpuinfo_apple_parse_performance_sample(cf_props, &sample);
+  CFRelease(cf_props);
+  if (!sample_valid)
     return;
-  }
 
-  id device_utilization_info = [performance_statistics objectForKey:@"Device Utilization %"];
-  if (device_utilization_info != nil) {
-    const uint64_t gpu_util_rate = [device_utilization_info integerValue];
-    SET_GPUINFO_DYNAMIC(dynamic_info, gpu_util_rate, gpu_util_rate);
-  }
+  if (sample.gpu_util_rate_valid)
+    SET_GPUINFO_DYNAMIC(dynamic_info, gpu_util_rate, sample.gpu_util_rate);
 
   if ([gpu_info->device hasUnifiedMemory]) {
     // [gpu_info->device currentAllocatedSize] returns the amount of memory allocated by this process, not
     // as allocated on the GPU globally. The performance statistics dictionary has the real value that we
     // are interested in, the amount of system memory allocated by the GPU.
-    id system_memory_info = [performance_statistics objectForKey:@"Alloc system memory"];
-    if (system_memory_info != nil) {
-      const uint64_t mem_used = [system_memory_info integerValue];
-      SET_GPUINFO_DYNAMIC(dynamic_info, used_memory, mem_used);
-    }
+    if (sample.allocated_system_memory_valid)
+      SET_GPUINFO_DYNAMIC(dynamic_info, used_memory, sample.allocated_system_memory);
 
     // Memory is unified, so query the amount of system memory instead.
     mach_msg_type_number_t host_size = HOST_BASIC_INFO_COUNT;
     host_basic_info_data_t info;
-    if (host_info(mach_host_self(), HOST_BASIC_INFO, (host_info_t) &info, &host_size) == KERN_SUCCESS) {
+    const mach_port_t host = mach_host_self();
+    const kern_return_t host_info_status = host_info(host, HOST_BASIC_INFO, (host_info_t)&info, &host_size);
+    mach_port_deallocate(mach_task_self(), host);
+    if (host_info_status == KERN_SUCCESS)
       SET_GPUINFO_DYNAMIC(dynamic_info, total_memory, info.max_mem);
-    }
   } else {
     // TODO: Figure out how to get used memory for this case.
 
@@ -209,9 +226,9 @@ static void gpuinfo_apple_refresh_dynamic_info(struct gpu_info *_gpu_info) {
     SET_GPUINFO_DYNAMIC(dynamic_info, total_memory, mem_total);
   }
 
-  CFRelease(props);
-
-  if (GPUINFO_DYNAMIC_FIELD_VALID(dynamic_info, used_memory) && GPUINFO_DYNAMIC_FIELD_VALID(dynamic_info, total_memory)) {
+  if (GPUINFO_DYNAMIC_FIELD_VALID(dynamic_info, used_memory) &&
+      GPUINFO_DYNAMIC_FIELD_VALID(dynamic_info, total_memory) && dynamic_info->total_memory &&
+      dynamic_info->used_memory <= dynamic_info->total_memory) {
     SET_GPUINFO_DYNAMIC(dynamic_info, free_memory, dynamic_info->total_memory - dynamic_info->used_memory);
     SET_GPUINFO_DYNAMIC(dynamic_info, mem_util_rate,
                         (dynamic_info->total_memory - dynamic_info->free_memory) * 100 / dynamic_info->total_memory);
@@ -245,7 +262,7 @@ static void gpuinfo_apple_get_running_processes(struct gpu_info *_gpu_info) {
         if (gpuinfo_apple_parse_process_sample(cf_props, &sample)) {
           bool gpu_usage_valid = false;
           unsigned gpu_usage = 0;
-          uint64_t registry_entry_id;
+          uint64_t registry_entry_id = 0;
           if (IORegistryEntryGetRegistryEntryID(child, &registry_entry_id) == kIOReturnSuccess) {
             const struct apple_process_cache_id client_id = {.registry_entry_id = registry_entry_id,
                                                               .pid = sample.pid};

--- a/src/extract_gpuinfo_apple.m
+++ b/src/extract_gpuinfo_apple.m
@@ -18,20 +18,48 @@
  *
  */
 
-#include "nvtop/common.h"
 #include "nvtop/device_discovery.h"
 #include "nvtop/extract_gpuinfo_common.h"
 #include "nvtop/time.h"
+#include "extract_gpuinfo_apple_utils.h"
+#include "uthash.h"
 
 #include <assert.h>
 #include <Metal/Metal.h>
 #include <IOKit/IOKitLib.h>
 #include <QuartzCore/QuartzCore.h>
 
+#define HASH_FIND_CLIENT(head, key_ptr, out_ptr)                                                                    \
+  HASH_FIND(hh, head, key_ptr, sizeof(struct apple_process_cache_id), out_ptr)
+#define HASH_ADD_CLIENT(head, in_ptr)                                                                               \
+  HASH_ADD(hh, head, client_id, sizeof(struct apple_process_cache_id), in_ptr)
+
+#define SET_APPLE_CACHE(cachePtr, field, value) SET_VALUE(cachePtr, field, value, apple_cache_)
+#define APPLE_CACHE_FIELD_VALID(cachePtr, field) VALUE_IS_VALID(cachePtr, field, apple_cache_)
+
+enum apple_process_info_cache_valid {
+  apple_cache_gpu_time_valid = 0,
+  apple_cache_process_info_cache_valid_count
+};
+
+struct __attribute__((__packed__)) apple_process_cache_id {
+  uint64_t registry_entry_id;
+  pid_t pid;
+};
+
+struct apple_process_info_cache {
+  struct apple_process_cache_id client_id;
+  uint64_t gpu_time;
+  nvtop_time last_measurement_tstamp;
+  unsigned char valid[(apple_cache_process_info_cache_valid_count + CHAR_BIT - 1) / CHAR_BIT];
+  UT_hash_handle hh;
+};
+
 struct gpu_info_apple {
   struct gpu_info base;
   id<MTLDevice> device;
   io_service_t gpu_service;
+  struct apple_process_info_cache *last_update_process_cache, *current_update_process_cache;
 };
 
 static bool gpuinfo_apple_init(void);
@@ -64,9 +92,26 @@ static bool gpuinfo_apple_init(void) {
   return true;
 }
 
+static void gpuinfo_apple_free_process_cache(struct apple_process_info_cache **process_cache) {
+  struct apple_process_info_cache *cache_entry, *tmp;
+  HASH_ITER(hh, *process_cache, cache_entry, tmp) {
+    HASH_DEL(*process_cache, cache_entry);
+    free(cache_entry);
+  }
+  *process_cache = NULL;
+}
+
+static void gpuinfo_apple_swap_process_cache_for_next_update(struct gpu_info_apple *gpu_info) {
+  gpuinfo_apple_free_process_cache(&gpu_info->last_update_process_cache);
+  gpu_info->last_update_process_cache = gpu_info->current_update_process_cache;
+  gpu_info->current_update_process_cache = NULL;
+}
+
 static void gpuinfo_apple_shutdown(void) {
   for (unsigned i = 0; i < apple_gpu_count; ++i) {
     struct gpu_info_apple *gpu_info = &gpu_infos[i];
+    gpuinfo_apple_free_process_cache(&gpu_info->last_update_process_cache);
+    gpuinfo_apple_free_process_cache(&gpu_info->current_update_process_cache);
     [gpu_info->device release];
     IOObjectRelease(gpu_info->gpu_service);
   }
@@ -174,35 +219,10 @@ static void gpuinfo_apple_refresh_dynamic_info(struct gpu_info *_gpu_info) {
   }
 }
 
-static bool gpuinfo_apple_get_process_info(struct gpu_process* process, io_object_t user_client) {
-  RESET_ALL(process->valid);
-  process->type = gpu_process_graphical_compute;
-
-  CFMutableDictionaryRef cf_props;
-  if (IORegistryEntryCreateCFProperties(user_client, &cf_props, kCFAllocatorDefault, kNilOptions) != kIOReturnSuccess) {
-    return false;
-  }
-  NSDictionary* user_client_info = (__bridge NSDictionary*) cf_props;
-
-  id client_creator_info = [user_client_info objectForKey:@"IOUserClientCreator"];
-  if (client_creator_info == nil) {
-    return false;
-  }
-
-  const char* client_creator = [client_creator_info UTF8String];
-  // Client creator is in form: pid <pid>, <name>
-  if (sscanf(client_creator, "pid %u,", &process->pid) < 1) {
-    return false;
-  }
-
-  CFRelease(cf_props);
-
-  return true;
-}
-
 static void gpuinfo_apple_get_running_processes(struct gpu_info *_gpu_info) {
   struct gpu_info_apple *gpu_info = container_of(_gpu_info, struct gpu_info_apple, base);
   _gpu_info->processes_count = 0;
+  gpuinfo_apple_swap_process_cache_for_next_update(gpu_info);
 
   // We can find out which processes are running on a particular GPU using the IO Registry. The
   // IOService associated to the MTLDevice has "AGXDeviceUserClient" child nodes, which hold some
@@ -213,30 +233,55 @@ static void gpuinfo_apple_get_running_processes(struct gpu_info *_gpu_info) {
     return;
   }
 
-  unsigned int count = 0;
+  nvtop_time current_time;
+  nvtop_get_current_time(&current_time);
   for (io_object_t child = IOIteratorNext(iterator); child; child = IOIteratorNext(iterator)) {
     io_name_t class_name;
-    if (IOObjectGetClass(child, class_name) != kIOReturnSuccess) {
-      continue;
-    } else if (strncmp(class_name, "AGXDeviceUserClient", sizeof(class_name)) != 0) {
-      continue;
-    }
+    if (IOObjectGetClass(child, class_name) == kIOReturnSuccess &&
+        strncmp(class_name, "AGXDeviceUserClient", sizeof(class_name)) == 0) {
+      CFMutableDictionaryRef cf_props;
+      if (IORegistryEntryCreateCFProperties(child, &cf_props, kCFAllocatorDefault, kNilOptions) == kIOReturnSuccess) {
+        struct gpuinfo_apple_process_sample sample = {0};
+        if (gpuinfo_apple_parse_process_sample(cf_props, &sample)) {
+          bool gpu_usage_valid = false;
+          unsigned gpu_usage = 0;
+          uint64_t registry_entry_id;
+          if (IORegistryEntryGetRegistryEntryID(child, &registry_entry_id) == kIOReturnSuccess) {
+            const struct apple_process_cache_id client_id = {.registry_entry_id = registry_entry_id,
+                                                              .pid = sample.pid};
+            struct apple_process_info_cache *cache_entry;
+            HASH_FIND_CLIENT(gpu_info->last_update_process_cache, &client_id, cache_entry);
+            if (cache_entry) {
+              HASH_DEL(gpu_info->last_update_process_cache, cache_entry);
+              if (sample.gpu_time_valid && APPLE_CACHE_FIELD_VALID(cache_entry, gpu_time)) {
+                const uint64_t time_elapsed =
+                    nvtop_difftime_u64(cache_entry->last_measurement_tstamp, current_time);
+                gpu_usage_valid = gpuinfo_apple_calculate_gpu_usage(cache_entry->gpu_time, sample.gpu_time,
+                                                                    time_elapsed, &gpu_usage);
+              }
+            } else {
+              cache_entry = calloc(1, sizeof(*cache_entry));
+              if (cache_entry)
+                cache_entry->client_id = client_id;
+            }
 
-    if (_gpu_info->processes_array_size < count + 1) {
-      _gpu_info->processes_array_size += COMMON_PROCESS_LINEAR_REALLOC_INC;
-      _gpu_info->processes = reallocarray(_gpu_info->processes, _gpu_info->processes_array_size, sizeof(*_gpu_info->processes));
-      if (!_gpu_info->processes) {
-        perror("Could not allocate memory: ");
-        exit(EXIT_FAILURE);
+            if (cache_entry) {
+              RESET_ALL(cache_entry->valid);
+              if (sample.gpu_time_valid)
+                SET_APPLE_CACHE(cache_entry, gpu_time, sample.gpu_time);
+              cache_entry->last_measurement_tstamp = current_time;
+              HASH_ADD_CLIENT(gpu_info->current_update_process_cache, cache_entry);
+            }
+          }
+
+          gpuinfo_apple_add_process(_gpu_info, sample.pid, gpu_usage_valid, gpu_usage);
+        }
+        CFRelease(cf_props);
       }
-    }
-
-    if (gpuinfo_apple_get_process_info(&_gpu_info->processes[count], child)) {
-      ++count;
     }
 
     IOObjectRelease(child);
   }
 
-  _gpu_info->processes_count = count;
+  IOObjectRelease(iterator);
 }

--- a/src/extract_gpuinfo_apple.m
+++ b/src/extract_gpuinfo_apple.m
@@ -213,6 +213,10 @@ static void gpuinfo_apple_refresh_dynamic_info(struct gpu_info *_gpu_info) {
   if (gpuinfo_apple_smc_get_gpu_temperature(gpu_info->smc, &temperature))
     SET_GPUINFO_DYNAMIC(dynamic_info, gpu_temp, temperature);
 
+  unsigned fan_rpm;
+  if (gpuinfo_apple_smc_get_fan_rpm(gpu_info->smc, &fan_rpm))
+    SET_GPUINFO_DYNAMIC(dynamic_info, fan_rpm, fan_rpm);
+
   CFMutableDictionaryRef cf_props;
   if (IORegistryEntryCreateCFProperties(gpu_info->gpu_service, &cf_props, kCFAllocatorDefault, kNilOptions) != kIOReturnSuccess) {
     return;

--- a/src/extract_gpuinfo_apple.m
+++ b/src/extract_gpuinfo_apple.m
@@ -21,6 +21,7 @@
 #include "nvtop/device_discovery.h"
 #include "nvtop/extract_gpuinfo_common.h"
 #include "nvtop/time.h"
+#include "extract_gpuinfo_apple_ioreport.h"
 #include "extract_gpuinfo_apple_utils.h"
 #include "uthash.h"
 
@@ -61,6 +62,7 @@ struct gpu_info_apple {
   struct gpu_info base;
   id<MTLDevice> device;
   io_service_t gpu_service;
+  struct gpuinfo_apple_ioreport *ioreport;
   struct apple_process_info_cache *last_update_process_cache, *current_update_process_cache;
 };
 
@@ -114,6 +116,7 @@ static void gpuinfo_apple_shutdown(void) {
     struct gpu_info_apple *gpu_info = &gpu_infos[i];
     gpuinfo_apple_free_process_cache(&gpu_info->last_update_process_cache);
     gpuinfo_apple_free_process_cache(&gpu_info->current_update_process_cache);
+    gpuinfo_apple_ioreport_shutdown(gpu_info->ioreport);
     [gpu_info->device release];
     IOObjectRelease(gpu_info->gpu_service);
   }
@@ -158,6 +161,8 @@ static bool gpuinfo_apple_get_device_handles(struct list_head *devices, unsigned
     gpu_info->base.vendor = &gpu_vendor_apple;
     gpu_info->device = [dev retain];
     gpu_info->gpu_service = gpu_service;
+    if ([dev hasUnifiedMemory] && [dev location] == MTLDeviceLocationBuiltIn)
+      gpuinfo_apple_ioreport_init(&gpu_info->ioreport);
     list_add_tail(&gpu_info->base.list, devices);
     ++apple_gpu_count;
   }
@@ -188,6 +193,10 @@ static void gpuinfo_apple_refresh_dynamic_info(struct gpu_info *_gpu_info) {
   struct gpu_info_apple *gpu_info = container_of(_gpu_info, struct gpu_info_apple, base);
   struct gpuinfo_dynamic_info *dynamic_info = &gpu_info->base.dynamic_info;
   RESET_ALL(dynamic_info->valid);
+
+  unsigned power_draw;
+  if (gpuinfo_apple_ioreport_get_power_draw(gpu_info->ioreport, &power_draw))
+    SET_GPUINFO_DYNAMIC(dynamic_info, power_draw, power_draw);
 
   CFMutableDictionaryRef cf_props;
   if (IORegistryEntryCreateCFProperties(gpu_info->gpu_service, &cf_props, kCFAllocatorDefault, kNilOptions) != kIOReturnSuccess) {

--- a/src/extract_gpuinfo_apple_ioreport.c
+++ b/src/extract_gpuinfo_apple_ioreport.c
@@ -1,0 +1,253 @@
+/*
+ *
+ * Copyright (C) 2026 NVTOP contributors
+ *
+ * This file is part of Nvtop.
+ *
+ * Nvtop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nvtop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with nvtop.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "extract_gpuinfo_apple_ioreport.h"
+
+#include "extract_gpuinfo_apple_utils.h"
+#include "nvtop/time.h"
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <dlfcn.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+// IOReport has no public user-space header. Keep its declarations in this file and load the
+// framework dynamically so an API or channel change only makes the extra metrics unavailable.
+typedef struct __IOReportSubscriptionRef *IOReportSubscriptionRef;
+
+struct gpuinfo_apple_ioreport_api {
+  CFDictionaryRef (*copy_channels_in_group)(CFStringRef, CFStringRef, uint64_t, uint64_t, uint64_t);
+  IOReportSubscriptionRef (*create_subscription)(const void *, CFMutableDictionaryRef, CFMutableDictionaryRef *,
+                                                 uint64_t, CFTypeRef);
+  CFDictionaryRef (*create_samples)(IOReportSubscriptionRef, CFMutableDictionaryRef, CFTypeRef);
+  CFDictionaryRef (*create_samples_delta)(CFDictionaryRef, CFDictionaryRef, CFTypeRef);
+  CFStringRef (*channel_get_name)(CFDictionaryRef);
+  CFStringRef (*channel_get_unit_label)(CFDictionaryRef);
+  int64_t (*simple_get_integer_value)(CFDictionaryRef, int);
+};
+
+struct gpuinfo_apple_ioreport {
+  void *library;
+  struct gpuinfo_apple_ioreport_api api;
+  IOReportSubscriptionRef energy_subscription;
+  CFMutableDictionaryRef energy_channels;
+  CFDictionaryRef previous_energy_sample;
+  nvtop_time previous_sample_time;
+};
+
+static bool gpuinfo_apple_ioreport_load_symbol(void *library, const char *name, void *destination,
+                                               size_t destination_size) {
+  void *symbol = dlsym(library, name);
+  if (!symbol || destination_size != sizeof(symbol))
+    return false;
+
+  memcpy(destination, &symbol, sizeof(symbol));
+  return true;
+}
+
+static bool gpuinfo_apple_ioreport_load_api(struct gpuinfo_apple_ioreport *ioreport) {
+#define LOAD_IOREPORT_SYMBOL(field, name)                                                                           \
+  if (!gpuinfo_apple_ioreport_load_symbol(ioreport->library, name, &ioreport->api.field,                            \
+                                          sizeof(ioreport->api.field)))                                              \
+    return false
+
+  LOAD_IOREPORT_SYMBOL(copy_channels_in_group, "IOReportCopyChannelsInGroup");
+  LOAD_IOREPORT_SYMBOL(create_subscription, "IOReportCreateSubscription");
+  LOAD_IOREPORT_SYMBOL(create_samples, "IOReportCreateSamples");
+  LOAD_IOREPORT_SYMBOL(create_samples_delta, "IOReportCreateSamplesDelta");
+  LOAD_IOREPORT_SYMBOL(channel_get_name, "IOReportChannelGetChannelName");
+  LOAD_IOREPORT_SYMBOL(channel_get_unit_label, "IOReportChannelGetUnitLabel");
+  LOAD_IOREPORT_SYMBOL(simple_get_integer_value, "IOReportSimpleGetIntegerValue");
+
+#undef LOAD_IOREPORT_SYMBOL
+  return true;
+}
+
+static bool gpuinfo_apple_ioreport_is_gpu_energy_channel(struct gpuinfo_apple_ioreport *ioreport,
+                                                         CFDictionaryRef channel) {
+  CFStringRef channel_name = ioreport->api.channel_get_name(channel);
+  return channel_name && CFGetTypeID(channel_name) == CFStringGetTypeID() &&
+         CFStringHasSuffix(channel_name, CFSTR("GPU Energy"));
+}
+
+static CFMutableDictionaryRef gpuinfo_apple_ioreport_copy_energy_channels(
+    struct gpuinfo_apple_ioreport *ioreport) {
+  CFDictionaryRef all_channels =
+      ioreport->api.copy_channels_in_group(CFSTR("Energy Model"), NULL, 0, 0, 0);
+  if (!all_channels || CFGetTypeID(all_channels) != CFDictionaryGetTypeID()) {
+    if (all_channels)
+      CFRelease(all_channels);
+    return NULL;
+  }
+
+  CFTypeRef channels_value = CFDictionaryGetValue(all_channels, CFSTR("IOReportChannels"));
+  if (!channels_value || CFGetTypeID(channels_value) != CFArrayGetTypeID()) {
+    CFRelease(all_channels);
+    return NULL;
+  }
+
+  CFArrayRef channels = channels_value;
+  CFMutableArrayRef energy_channels =
+      CFArrayCreateMutable(kCFAllocatorDefault, 0, &kCFTypeArrayCallBacks);
+  if (!energy_channels) {
+    CFRelease(all_channels);
+    return NULL;
+  }
+
+  for (CFIndex i = 0; i < CFArrayGetCount(channels); ++i) {
+    CFTypeRef channel_value = CFArrayGetValueAtIndex(channels, i);
+    if (channel_value && CFGetTypeID(channel_value) == CFDictionaryGetTypeID() &&
+        gpuinfo_apple_ioreport_is_gpu_energy_channel(ioreport, channel_value))
+      CFArrayAppendValue(energy_channels, channel_value);
+  }
+
+  CFMutableDictionaryRef selected_channels = NULL;
+  if (CFArrayGetCount(energy_channels)) {
+    selected_channels = CFDictionaryCreateMutableCopy(kCFAllocatorDefault, 0, all_channels);
+    if (selected_channels)
+      CFDictionarySetValue(selected_channels, CFSTR("IOReportChannels"), energy_channels);
+  }
+
+  CFRelease(energy_channels);
+  CFRelease(all_channels);
+  return selected_channels;
+}
+
+bool gpuinfo_apple_ioreport_init(struct gpuinfo_apple_ioreport **ioreport) {
+  if (!ioreport)
+    return false;
+  *ioreport = NULL;
+
+  struct gpuinfo_apple_ioreport *new_ioreport = calloc(1, sizeof(*new_ioreport));
+  if (!new_ioreport)
+    return false;
+
+  new_ioreport->library = dlopen("/usr/lib/libIOReport.dylib", RTLD_LAZY | RTLD_LOCAL);
+  if (!new_ioreport->library || !gpuinfo_apple_ioreport_load_api(new_ioreport)) {
+    gpuinfo_apple_ioreport_shutdown(new_ioreport);
+    return false;
+  }
+
+  CFMutableDictionaryRef requested_channels = gpuinfo_apple_ioreport_copy_energy_channels(new_ioreport);
+  if (!requested_channels) {
+    gpuinfo_apple_ioreport_shutdown(new_ioreport);
+    return false;
+  }
+
+  new_ioreport->energy_subscription = new_ioreport->api.create_subscription(
+      NULL, requested_channels, &new_ioreport->energy_channels, 0, NULL);
+  CFRelease(requested_channels);
+  if (!new_ioreport->energy_subscription || !new_ioreport->energy_channels ||
+      CFGetTypeID(new_ioreport->energy_channels) != CFDictionaryGetTypeID()) {
+    gpuinfo_apple_ioreport_shutdown(new_ioreport);
+    return false;
+  }
+
+  *ioreport = new_ioreport;
+  return true;
+}
+
+void gpuinfo_apple_ioreport_shutdown(struct gpuinfo_apple_ioreport *ioreport) {
+  if (!ioreport)
+    return;
+
+  if (ioreport->previous_energy_sample)
+    CFRelease(ioreport->previous_energy_sample);
+  if (ioreport->energy_subscription)
+    CFRelease(ioreport->energy_subscription);
+  if (ioreport->energy_channels)
+    CFRelease(ioreport->energy_channels);
+  if (ioreport->library)
+    dlclose(ioreport->library);
+  free(ioreport);
+}
+
+static bool gpuinfo_apple_ioreport_parse_power_draw(struct gpuinfo_apple_ioreport *ioreport,
+                                                    CFDictionaryRef energy_delta, uint64_t elapsed,
+                                                    unsigned *power_draw) {
+  if (!energy_delta || CFGetTypeID(energy_delta) != CFDictionaryGetTypeID())
+    return false;
+
+  CFTypeRef channels_value = CFDictionaryGetValue(energy_delta, CFSTR("IOReportChannels"));
+  if (!channels_value || CFGetTypeID(channels_value) != CFArrayGetTypeID())
+    return false;
+
+  uint64_t total_energy = 0;
+  bool energy_valid = false;
+  CFArrayRef channels = channels_value;
+  for (CFIndex i = 0; i < CFArrayGetCount(channels); ++i) {
+    CFTypeRef channel_value = CFArrayGetValueAtIndex(channels, i);
+    if (!channel_value || CFGetTypeID(channel_value) != CFDictionaryGetTypeID() ||
+        !gpuinfo_apple_ioreport_is_gpu_energy_channel(ioreport, channel_value))
+      continue;
+
+    CFStringRef unit_label = ioreport->api.channel_get_unit_label(channel_value);
+    char unit[8];
+    if (!unit_label || CFGetTypeID(unit_label) != CFStringGetTypeID() ||
+        !CFStringGetCString(unit_label, unit, sizeof(unit), kCFStringEncodingUTF8))
+      continue;
+
+    const int64_t raw_energy = ioreport->api.simple_get_integer_value(channel_value, 0);
+    uint64_t energy;
+    if (!gpuinfo_apple_energy_to_nanojoules(raw_energy, unit, &energy) || UINT64_MAX - total_energy < energy)
+      continue;
+
+    total_energy += energy;
+    energy_valid = true;
+  }
+
+  return energy_valid && gpuinfo_apple_calculate_power_draw(total_energy, elapsed, power_draw);
+}
+
+bool gpuinfo_apple_ioreport_get_power_draw(struct gpuinfo_apple_ioreport *ioreport, unsigned *power_draw) {
+  if (!ioreport || !power_draw)
+    return false;
+
+  CFDictionaryRef current_sample =
+      ioreport->api.create_samples(ioreport->energy_subscription, ioreport->energy_channels, NULL);
+  if (!current_sample)
+    return false;
+
+  nvtop_time current_time;
+  nvtop_get_current_time(&current_time);
+  if (!ioreport->previous_energy_sample) {
+    ioreport->previous_energy_sample = current_sample;
+    ioreport->previous_sample_time = current_time;
+    return false;
+  }
+
+  CFDictionaryRef previous_sample = ioreport->previous_energy_sample;
+  const nvtop_time previous_time = ioreport->previous_sample_time;
+  ioreport->previous_energy_sample = current_sample;
+  ioreport->previous_sample_time = current_time;
+
+  CFDictionaryRef energy_delta = ioreport->api.create_samples_delta(previous_sample, current_sample, NULL);
+  CFRelease(previous_sample);
+  if (!energy_delta)
+    return false;
+
+  const uint64_t elapsed = nvtop_difftime_u64(previous_time, current_time);
+  const bool power_draw_valid =
+      gpuinfo_apple_ioreport_parse_power_draw(ioreport, energy_delta, elapsed, power_draw);
+  CFRelease(energy_delta);
+  return power_draw_valid;
+}

--- a/src/extract_gpuinfo_apple_ioreport.c
+++ b/src/extract_gpuinfo_apple_ioreport.c
@@ -25,6 +25,7 @@
 #include "nvtop/time.h"
 
 #include <CoreFoundation/CoreFoundation.h>
+#include <IOKit/IOKitLib.h>
 #include <dlfcn.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -43,15 +44,26 @@ struct gpuinfo_apple_ioreport_api {
   CFStringRef (*channel_get_name)(CFDictionaryRef);
   CFStringRef (*channel_get_unit_label)(CFDictionaryRef);
   int64_t (*simple_get_integer_value)(CFDictionaryRef, int);
+  int (*state_get_count)(CFDictionaryRef);
+  CFStringRef (*state_get_name_for_index)(CFDictionaryRef, int);
+  int64_t (*state_get_residency)(CFDictionaryRef, int);
 };
 
 struct gpuinfo_apple_ioreport {
   void *library;
   struct gpuinfo_apple_ioreport_api api;
+  bool energy_api_available;
+  bool performance_state_api_available;
   IOReportSubscriptionRef energy_subscription;
   CFMutableDictionaryRef energy_channels;
   CFDictionaryRef previous_energy_sample;
   nvtop_time previous_sample_time;
+  IOReportSubscriptionRef performance_state_subscription;
+  CFMutableDictionaryRef performance_state_channels;
+  CFDictionaryRef previous_performance_state_sample;
+  unsigned *gpu_frequencies;
+  size_t gpu_frequency_count;
+  unsigned max_gpu_frequency;
 };
 
 static bool gpuinfo_apple_ioreport_load_symbol(void *library, const char *name, void *destination,
@@ -65,20 +77,62 @@ static bool gpuinfo_apple_ioreport_load_symbol(void *library, const char *name, 
 }
 
 static bool gpuinfo_apple_ioreport_load_api(struct gpuinfo_apple_ioreport *ioreport) {
-#define LOAD_IOREPORT_SYMBOL(field, name)                                                                           \
+#define LOAD_REQUIRED_IOREPORT_SYMBOL(field, name)                                                                  \
   if (!gpuinfo_apple_ioreport_load_symbol(ioreport->library, name, &ioreport->api.field,                            \
                                           sizeof(ioreport->api.field)))                                              \
     return false
 
-  LOAD_IOREPORT_SYMBOL(copy_channels_in_group, "IOReportCopyChannelsInGroup");
-  LOAD_IOREPORT_SYMBOL(create_subscription, "IOReportCreateSubscription");
-  LOAD_IOREPORT_SYMBOL(create_samples, "IOReportCreateSamples");
-  LOAD_IOREPORT_SYMBOL(create_samples_delta, "IOReportCreateSamplesDelta");
-  LOAD_IOREPORT_SYMBOL(channel_get_name, "IOReportChannelGetChannelName");
-  LOAD_IOREPORT_SYMBOL(channel_get_unit_label, "IOReportChannelGetUnitLabel");
-  LOAD_IOREPORT_SYMBOL(simple_get_integer_value, "IOReportSimpleGetIntegerValue");
+  LOAD_REQUIRED_IOREPORT_SYMBOL(copy_channels_in_group, "IOReportCopyChannelsInGroup");
+  LOAD_REQUIRED_IOREPORT_SYMBOL(create_subscription, "IOReportCreateSubscription");
+  LOAD_REQUIRED_IOREPORT_SYMBOL(create_samples, "IOReportCreateSamples");
+  LOAD_REQUIRED_IOREPORT_SYMBOL(create_samples_delta, "IOReportCreateSamplesDelta");
 
-#undef LOAD_IOREPORT_SYMBOL
+#undef LOAD_REQUIRED_IOREPORT_SYMBOL
+
+  ioreport->energy_api_available =
+      gpuinfo_apple_ioreport_load_symbol(ioreport->library, "IOReportChannelGetChannelName",
+                                         &ioreport->api.channel_get_name,
+                                         sizeof(ioreport->api.channel_get_name)) &&
+      gpuinfo_apple_ioreport_load_symbol(ioreport->library, "IOReportChannelGetUnitLabel",
+                                         &ioreport->api.channel_get_unit_label,
+                                         sizeof(ioreport->api.channel_get_unit_label)) &&
+      gpuinfo_apple_ioreport_load_symbol(ioreport->library, "IOReportSimpleGetIntegerValue",
+                                         &ioreport->api.simple_get_integer_value,
+                                         sizeof(ioreport->api.simple_get_integer_value));
+  ioreport->performance_state_api_available =
+      gpuinfo_apple_ioreport_load_symbol(ioreport->library, "IOReportStateGetCount",
+                                         &ioreport->api.state_get_count,
+                                         sizeof(ioreport->api.state_get_count)) &&
+      gpuinfo_apple_ioreport_load_symbol(ioreport->library, "IOReportStateGetNameForIndex",
+                                         &ioreport->api.state_get_name_for_index,
+                                         sizeof(ioreport->api.state_get_name_for_index)) &&
+      gpuinfo_apple_ioreport_load_symbol(ioreport->library, "IOReportStateGetResidency",
+                                         &ioreport->api.state_get_residency,
+                                         sizeof(ioreport->api.state_get_residency));
+  return true;
+}
+
+static void gpuinfo_apple_ioreport_release_subscription(IOReportSubscriptionRef *subscription,
+                                                        CFMutableDictionaryRef *channels) {
+  if (*subscription)
+    CFRelease(*subscription);
+  if (*channels)
+    CFRelease(*channels);
+  *subscription = NULL;
+  *channels = NULL;
+}
+
+static bool gpuinfo_apple_ioreport_create_subscription(struct gpuinfo_apple_ioreport *ioreport,
+                                                       CFMutableDictionaryRef requested_channels,
+                                                       IOReportSubscriptionRef *subscription,
+                                                       CFMutableDictionaryRef *subscribed_channels) {
+  *subscription =
+      ioreport->api.create_subscription(NULL, requested_channels, subscribed_channels, 0, NULL);
+  if (!*subscription || !*subscribed_channels ||
+      CFGetTypeID(*subscribed_channels) != CFDictionaryGetTypeID()) {
+    gpuinfo_apple_ioreport_release_subscription(subscription, subscribed_channels);
+    return false;
+  }
   return true;
 }
 
@@ -132,6 +186,78 @@ static CFMutableDictionaryRef gpuinfo_apple_ioreport_copy_energy_channels(
   return selected_channels;
 }
 
+static CFMutableDictionaryRef gpuinfo_apple_ioreport_copy_performance_state_channels(
+    struct gpuinfo_apple_ioreport *ioreport) {
+  CFDictionaryRef channels = ioreport->api.copy_channels_in_group(
+      CFSTR("GPU Stats"), CFSTR("GPU Performance States"), 0, 0, 0);
+  if (!channels || CFGetTypeID(channels) != CFDictionaryGetTypeID()) {
+    if (channels)
+      CFRelease(channels);
+    return NULL;
+  }
+
+  CFTypeRef channel_array = CFDictionaryGetValue(channels, CFSTR("IOReportChannels"));
+  if (!channel_array || CFGetTypeID(channel_array) != CFArrayGetTypeID() ||
+      !CFArrayGetCount(channel_array)) {
+    CFRelease(channels);
+    return NULL;
+  }
+
+  CFMutableDictionaryRef mutable_channels =
+      CFDictionaryCreateMutableCopy(kCFAllocatorDefault, 0, channels);
+  CFRelease(channels);
+  return mutable_channels;
+}
+
+static bool gpuinfo_apple_ioreport_load_gpu_frequencies(struct gpuinfo_apple_ioreport *ioreport) {
+  io_service_t power_manager =
+      IOServiceGetMatchingService(kIOMainPortDefault, IOServiceNameMatching("pmgr"));
+  if (!MACH_PORT_VALID(power_manager))
+    return false;
+
+  CFTypeRef voltage_states = IORegistryEntryCreateCFProperty(
+      power_manager, CFSTR("voltage-states9"), kCFAllocatorDefault, kNilOptions);
+  IOObjectRelease(power_manager);
+  if (!voltage_states || CFGetTypeID(voltage_states) != CFDataGetTypeID()) {
+    if (voltage_states)
+      CFRelease(voltage_states);
+    return false;
+  }
+
+  const CFIndex data_size = CFDataGetLength(voltage_states);
+  if (data_size <= 0 || data_size % 8) {
+    CFRelease(voltage_states);
+    return false;
+  }
+
+  const size_t state_count = (size_t)data_size / 8;
+  unsigned *frequencies = calloc(state_count, sizeof(*frequencies));
+  size_t frequency_count;
+  const bool frequencies_valid = frequencies && gpuinfo_apple_parse_gpu_frequency_states(
+                                                    CFDataGetBytePtr(voltage_states), (size_t)data_size,
+                                                    frequencies, state_count, &frequency_count);
+  CFRelease(voltage_states);
+  if (!frequencies_valid) {
+    free(frequencies);
+    return false;
+  }
+
+  unsigned max_frequency = 0;
+  for (size_t i = 1; i < frequency_count; ++i) {
+    if (frequencies[i] > max_frequency)
+      max_frequency = frequencies[i];
+  }
+  if (!max_frequency) {
+    free(frequencies);
+    return false;
+  }
+
+  ioreport->gpu_frequencies = frequencies;
+  ioreport->gpu_frequency_count = frequency_count;
+  ioreport->max_gpu_frequency = max_frequency;
+  return true;
+}
+
 bool gpuinfo_apple_ioreport_init(struct gpuinfo_apple_ioreport **ioreport) {
   if (!ioreport)
     return false;
@@ -147,17 +273,36 @@ bool gpuinfo_apple_ioreport_init(struct gpuinfo_apple_ioreport **ioreport) {
     return false;
   }
 
-  CFMutableDictionaryRef requested_channels = gpuinfo_apple_ioreport_copy_energy_channels(new_ioreport);
-  if (!requested_channels) {
-    gpuinfo_apple_ioreport_shutdown(new_ioreport);
-    return false;
+  bool source_available = false;
+  CFMutableDictionaryRef requested_channels = NULL;
+  if (new_ioreport->energy_api_available)
+    requested_channels = gpuinfo_apple_ioreport_copy_energy_channels(new_ioreport);
+  if (requested_channels) {
+    source_available = gpuinfo_apple_ioreport_create_subscription(
+        new_ioreport, requested_channels, &new_ioreport->energy_subscription,
+        &new_ioreport->energy_channels);
+    CFRelease(requested_channels);
   }
 
-  new_ioreport->energy_subscription = new_ioreport->api.create_subscription(
-      NULL, requested_channels, &new_ioreport->energy_channels, 0, NULL);
-  CFRelease(requested_channels);
-  if (!new_ioreport->energy_subscription || !new_ioreport->energy_channels ||
-      CFGetTypeID(new_ioreport->energy_channels) != CFDictionaryGetTypeID()) {
+  if (new_ioreport->performance_state_api_available &&
+      gpuinfo_apple_ioreport_load_gpu_frequencies(new_ioreport)) {
+    requested_channels = gpuinfo_apple_ioreport_copy_performance_state_channels(new_ioreport);
+    if (requested_channels) {
+      const bool performance_states_available = gpuinfo_apple_ioreport_create_subscription(
+          new_ioreport, requested_channels, &new_ioreport->performance_state_subscription,
+          &new_ioreport->performance_state_channels);
+      source_available = source_available || performance_states_available;
+      CFRelease(requested_channels);
+    }
+    if (!new_ioreport->performance_state_subscription) {
+      free(new_ioreport->gpu_frequencies);
+      new_ioreport->gpu_frequencies = NULL;
+      new_ioreport->gpu_frequency_count = 0;
+      new_ioreport->max_gpu_frequency = 0;
+    }
+  }
+
+  if (!source_available) {
     gpuinfo_apple_ioreport_shutdown(new_ioreport);
     return false;
   }
@@ -172,10 +317,13 @@ void gpuinfo_apple_ioreport_shutdown(struct gpuinfo_apple_ioreport *ioreport) {
 
   if (ioreport->previous_energy_sample)
     CFRelease(ioreport->previous_energy_sample);
-  if (ioreport->energy_subscription)
-    CFRelease(ioreport->energy_subscription);
-  if (ioreport->energy_channels)
-    CFRelease(ioreport->energy_channels);
+  if (ioreport->previous_performance_state_sample)
+    CFRelease(ioreport->previous_performance_state_sample);
+  gpuinfo_apple_ioreport_release_subscription(&ioreport->energy_subscription,
+                                              &ioreport->energy_channels);
+  gpuinfo_apple_ioreport_release_subscription(&ioreport->performance_state_subscription,
+                                              &ioreport->performance_state_channels);
+  free(ioreport->gpu_frequencies);
   if (ioreport->library)
     dlclose(ioreport->library);
   free(ioreport);
@@ -219,7 +367,8 @@ static bool gpuinfo_apple_ioreport_parse_power_draw(struct gpuinfo_apple_iorepor
 }
 
 bool gpuinfo_apple_ioreport_get_power_draw(struct gpuinfo_apple_ioreport *ioreport, unsigned *power_draw) {
-  if (!ioreport || !power_draw)
+  if (!ioreport || !ioreport->energy_api_available || !ioreport->energy_subscription ||
+      !power_draw)
     return false;
 
   CFDictionaryRef current_sample =
@@ -250,4 +399,95 @@ bool gpuinfo_apple_ioreport_get_power_draw(struct gpuinfo_apple_ioreport *iorepo
       gpuinfo_apple_ioreport_parse_power_draw(ioreport, energy_delta, elapsed, power_draw);
   CFRelease(energy_delta);
   return power_draw_valid;
+}
+
+static bool gpuinfo_apple_ioreport_parse_gpu_clock_speed(struct gpuinfo_apple_ioreport *ioreport,
+                                                         CFDictionaryRef performance_state_delta,
+                                                         unsigned *clock_speed) {
+  if (!performance_state_delta ||
+      CFGetTypeID(performance_state_delta) != CFDictionaryGetTypeID())
+    return false;
+
+  CFTypeRef channels_value =
+      CFDictionaryGetValue(performance_state_delta, CFSTR("IOReportChannels"));
+  if (!channels_value || CFGetTypeID(channels_value) != CFArrayGetTypeID())
+    return false;
+
+  uint64_t *residencies = calloc(ioreport->gpu_frequency_count, sizeof(*residencies));
+  if (!residencies)
+    return false;
+
+  bool residency_valid = false;
+  CFArrayRef channels = channels_value;
+  for (CFIndex i = 0; i < CFArrayGetCount(channels); ++i) {
+    CFTypeRef channel_value = CFArrayGetValueAtIndex(channels, i);
+    if (!channel_value || CFGetTypeID(channel_value) != CFDictionaryGetTypeID())
+      continue;
+
+    const int state_count = ioreport->api.state_get_count(channel_value);
+    if (state_count < 2 || (size_t)state_count < ioreport->gpu_frequency_count)
+      continue;
+
+    CFStringRef first_state = ioreport->api.state_get_name_for_index(channel_value, 0);
+    if (!first_state || CFGetTypeID(first_state) != CFStringGetTypeID() ||
+        CFStringCompare(first_state, CFSTR("OFF"), 0) != kCFCompareEqualTo)
+      continue;
+
+    // State zero maps to voltage-states9's zero-frequency entry. Aggregate the subsequent
+    // active-state residencies across channels before calculating a multi-die average.
+    bool channel_valid = true;
+    for (size_t state = 1; state < ioreport->gpu_frequency_count; ++state) {
+      const int64_t residency = ioreport->api.state_get_residency(channel_value, (int)state);
+      if (residency < 0 || UINT64_MAX - residencies[state] < (uint64_t)residency) {
+        channel_valid = false;
+        break;
+      }
+    }
+    if (!channel_valid)
+      continue;
+
+    for (size_t state = 1; state < ioreport->gpu_frequency_count; ++state)
+      residencies[state] +=
+          (uint64_t)ioreport->api.state_get_residency(channel_value, (int)state);
+    residency_valid = true;
+  }
+
+  const bool clock_speed_valid =
+      residency_valid && gpuinfo_apple_calculate_gpu_clock_speed(
+                             residencies, ioreport->gpu_frequencies,
+                             ioreport->gpu_frequency_count, clock_speed);
+  free(residencies);
+  return clock_speed_valid;
+}
+
+bool gpuinfo_apple_ioreport_get_gpu_clock_speed(struct gpuinfo_apple_ioreport *ioreport,
+                                               unsigned *clock_speed, unsigned *max_clock_speed) {
+  if (!ioreport || !ioreport->performance_state_api_available ||
+      !ioreport->performance_state_subscription || !clock_speed || !max_clock_speed)
+    return false;
+
+  CFDictionaryRef current_sample = ioreport->api.create_samples(
+      ioreport->performance_state_subscription, ioreport->performance_state_channels, NULL);
+  if (!current_sample)
+    return false;
+
+  if (!ioreport->previous_performance_state_sample) {
+    ioreport->previous_performance_state_sample = current_sample;
+    return false;
+  }
+
+  CFDictionaryRef previous_sample = ioreport->previous_performance_state_sample;
+  ioreport->previous_performance_state_sample = current_sample;
+  CFDictionaryRef state_delta =
+      ioreport->api.create_samples_delta(previous_sample, current_sample, NULL);
+  CFRelease(previous_sample);
+  if (!state_delta)
+    return false;
+
+  const bool clock_speed_valid =
+      gpuinfo_apple_ioreport_parse_gpu_clock_speed(ioreport, state_delta, clock_speed);
+  CFRelease(state_delta);
+  if (clock_speed_valid)
+    *max_clock_speed = ioreport->max_gpu_frequency;
+  return clock_speed_valid;
 }

--- a/src/extract_gpuinfo_apple_ioreport.h
+++ b/src/extract_gpuinfo_apple_ioreport.h
@@ -29,5 +29,7 @@ struct gpuinfo_apple_ioreport;
 bool gpuinfo_apple_ioreport_init(struct gpuinfo_apple_ioreport **ioreport);
 void gpuinfo_apple_ioreport_shutdown(struct gpuinfo_apple_ioreport *ioreport);
 bool gpuinfo_apple_ioreport_get_power_draw(struct gpuinfo_apple_ioreport *ioreport, unsigned *power_draw);
+bool gpuinfo_apple_ioreport_get_gpu_clock_speed(struct gpuinfo_apple_ioreport *ioreport, unsigned *clock_speed,
+                                               unsigned *max_clock_speed);
 
 #endif // EXTRACT_GPUINFO_APPLE_IOREPORT_H_

--- a/src/extract_gpuinfo_apple_ioreport.h
+++ b/src/extract_gpuinfo_apple_ioreport.h
@@ -1,0 +1,33 @@
+/*
+ *
+ * Copyright (C) 2026 NVTOP contributors
+ *
+ * This file is part of Nvtop.
+ *
+ * Nvtop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nvtop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with nvtop.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef EXTRACT_GPUINFO_APPLE_IOREPORT_H_
+#define EXTRACT_GPUINFO_APPLE_IOREPORT_H_
+
+#include <stdbool.h>
+
+struct gpuinfo_apple_ioreport;
+
+bool gpuinfo_apple_ioreport_init(struct gpuinfo_apple_ioreport **ioreport);
+void gpuinfo_apple_ioreport_shutdown(struct gpuinfo_apple_ioreport *ioreport);
+bool gpuinfo_apple_ioreport_get_power_draw(struct gpuinfo_apple_ioreport *ioreport, unsigned *power_draw);
+
+#endif // EXTRACT_GPUINFO_APPLE_IOREPORT_H_

--- a/src/extract_gpuinfo_apple_smc.c
+++ b/src/extract_gpuinfo_apple_smc.c
@@ -32,7 +32,7 @@
 #include <string.h>
 
 // AppleSMC has no public user-space protocol. Keep its wire structures and commands isolated
-// here so changes make temperature unavailable without affecting the other Apple metrics.
+// here so changes make SMC metrics unavailable without affecting the other Apple metrics.
 struct apple_smc_version {
   uint8_t major;
   uint8_t minor;
@@ -74,20 +74,27 @@ _Static_assert(offsetof(struct apple_smc_key_data, bytes) == 48, "Unexpected App
 _Static_assert(sizeof(struct apple_smc_key_data) == 80, "Unexpected AppleSMC payload size");
 _Static_assert(sizeof(float) == 4, "Unexpected AppleSMC float size");
 
-struct apple_smc_temperature_key {
+struct apple_smc_sensor_key {
   uint32_t key;
   struct apple_smc_key_info info;
 };
 
 struct gpuinfo_apple_smc {
   io_connect_t connection;
-  struct apple_smc_temperature_key *temperature_keys;
+  struct apple_smc_sensor_key *temperature_keys;
   size_t temperature_key_count;
   float *temperature_samples;
-  nvtop_time last_sample_time;
+  struct apple_smc_sensor_key *fan_keys;
+  size_t fan_key_count;
+  float *fan_samples;
+  nvtop_time last_temperature_sample_time;
+  nvtop_time last_fan_sample_time;
   unsigned last_temperature;
-  bool sample_attempted;
+  unsigned last_fan_rpm;
+  bool temperature_sample_attempted;
+  bool fan_sample_attempted;
   bool last_temperature_valid;
+  bool last_fan_rpm_valid;
 };
 
 enum apple_smc_command {
@@ -201,11 +208,7 @@ static bool gpuinfo_apple_smc_open(struct gpuinfo_apple_smc *smc) {
   return MACH_PORT_VALID(smc->connection);
 }
 
-static bool gpuinfo_apple_smc_discover_temperature_keys(struct gpuinfo_apple_smc *smc) {
-  uint32_t key_count;
-  if (!gpuinfo_apple_smc_read_key_count(smc, &key_count))
-    return false;
-
+static bool gpuinfo_apple_smc_discover_temperature_keys(struct gpuinfo_apple_smc *smc, uint32_t key_count) {
   // SMC enumerates keys in lexicographic FourCC order. Locate only the lowercase Tg range
   // instead of scanning thousands of keys, then validate that ordering while caching the range.
   const uint32_t first_gpu_temperature_key = gpuinfo_apple_smc_key_id("Tg\0\0");
@@ -217,7 +220,7 @@ static bool gpuinfo_apple_smc_discover_temperature_keys(struct gpuinfo_apple_smc
     return false;
 
   const size_t maximum_key_count = end_index - first_index;
-  struct apple_smc_temperature_key *keys = calloc(maximum_key_count, sizeof(*keys));
+  struct apple_smc_sensor_key *keys = calloc(maximum_key_count, sizeof(*keys));
   if (!keys)
     return false;
 
@@ -237,7 +240,7 @@ static bool gpuinfo_apple_smc_discover_temperature_keys(struct gpuinfo_apple_smc
     if (!gpuinfo_apple_smc_read_key_info(smc, key, &info) || info.data_size != sizeof(float) ||
         info.data_type != float_type)
       continue;
-    keys[valid_key_count++] = (struct apple_smc_temperature_key){.key = key, .info = info};
+    keys[valid_key_count++] = (struct apple_smc_sensor_key){.key = key, .info = info};
   }
 
   if (!valid_key_count) {
@@ -245,11 +248,69 @@ static bool gpuinfo_apple_smc_discover_temperature_keys(struct gpuinfo_apple_smc
     return false;
   }
 
+  float *samples = calloc(valid_key_count, sizeof(*samples));
+  if (!samples) {
+    free(keys);
+    return false;
+  }
+
   smc->temperature_keys = keys;
   smc->temperature_key_count = valid_key_count;
-  smc->temperature_samples = calloc(valid_key_count, sizeof(*smc->temperature_samples));
-  if (!smc->temperature_samples)
+  smc->temperature_samples = samples;
+  return true;
+}
+
+static bool gpuinfo_apple_smc_discover_fan_keys(struct gpuinfo_apple_smc *smc, uint32_t key_count) {
+  // Current fan speeds use F?Ac keys. Search the complete F range, then retain only
+  // matching float sensors so unrelated fan limits and metadata are ignored.
+  const uint32_t first_fan_key = gpuinfo_apple_smc_key_id("F\0\0\0");
+  const uint32_t end_fan_key = gpuinfo_apple_smc_key_id("G\0\0\0");
+  uint32_t first_index, end_index;
+  if (!gpuinfo_apple_smc_lower_bound(smc, key_count, first_fan_key, &first_index) ||
+      !gpuinfo_apple_smc_lower_bound(smc, key_count, end_fan_key, &end_index) ||
+      first_index >= end_index)
     return false;
+
+  const size_t maximum_key_count = end_index - first_index;
+  struct apple_smc_sensor_key *keys = calloc(maximum_key_count, sizeof(*keys));
+  if (!keys)
+    return false;
+
+  uint32_t previous_key = 0;
+  size_t valid_key_count = 0;
+  const uint32_t fan_key_pattern = gpuinfo_apple_smc_key_id("F\0Ac");
+  const uint32_t fan_key_mask = UINT32_C(0xff00ffff);
+  const uint32_t float_type = gpuinfo_apple_smc_key_id("flt ");
+  for (uint32_t index = first_index; index < end_index; ++index) {
+    uint32_t key;
+    if (!gpuinfo_apple_smc_read_key_by_index(smc, index, &key) || key < first_fan_key ||
+        key >= end_fan_key || (index != first_index && key <= previous_key)) {
+      free(keys);
+      return false;
+    }
+    previous_key = key;
+
+    struct apple_smc_key_info info;
+    if ((key & fan_key_mask) != fan_key_pattern || !gpuinfo_apple_smc_read_key_info(smc, key, &info) ||
+        info.data_size != sizeof(float) || info.data_type != float_type)
+      continue;
+    keys[valid_key_count++] = (struct apple_smc_sensor_key){.key = key, .info = info};
+  }
+
+  if (!valid_key_count) {
+    free(keys);
+    return false;
+  }
+
+  float *samples = calloc(valid_key_count, sizeof(*samples));
+  if (!samples) {
+    free(keys);
+    return false;
+  }
+
+  smc->fan_keys = keys;
+  smc->fan_key_count = valid_key_count;
+  smc->fan_samples = samples;
   return true;
 }
 
@@ -262,7 +323,15 @@ bool gpuinfo_apple_smc_init(struct gpuinfo_apple_smc **smc) {
   if (!new_smc)
     return false;
 
-  if (!gpuinfo_apple_smc_open(new_smc) || !gpuinfo_apple_smc_discover_temperature_keys(new_smc)) {
+  uint32_t key_count;
+  if (!gpuinfo_apple_smc_open(new_smc) || !gpuinfo_apple_smc_read_key_count(new_smc, &key_count)) {
+    gpuinfo_apple_smc_shutdown(new_smc);
+    return false;
+  }
+
+  const bool temperature_keys_valid = gpuinfo_apple_smc_discover_temperature_keys(new_smc, key_count);
+  const bool fan_keys_valid = gpuinfo_apple_smc_discover_fan_keys(new_smc, key_count);
+  if (!temperature_keys_valid && !fan_keys_valid) {
     gpuinfo_apple_smc_shutdown(new_smc);
     return false;
   }
@@ -277,25 +346,27 @@ void gpuinfo_apple_smc_shutdown(struct gpuinfo_apple_smc *smc) {
 
   if (MACH_PORT_VALID(smc->connection))
     IOServiceClose(smc->connection);
+  free(smc->fan_samples);
+  free(smc->fan_keys);
   free(smc->temperature_samples);
   free(smc->temperature_keys);
   free(smc);
 }
 
 bool gpuinfo_apple_smc_get_gpu_temperature(struct gpuinfo_apple_smc *smc, unsigned *temperature) {
-  if (!smc || !temperature)
+  if (!smc || !temperature || !smc->temperature_key_count)
     return false;
 
   nvtop_time current_time;
   nvtop_get_current_time(&current_time);
-  if (smc->sample_attempted &&
-      nvtop_difftime_u64(smc->last_sample_time, current_time) < apple_smc_minimum_sample_interval) {
+  if (smc->temperature_sample_attempted &&
+      nvtop_difftime_u64(smc->last_temperature_sample_time, current_time) < apple_smc_minimum_sample_interval) {
     if (smc->last_temperature_valid)
       *temperature = smc->last_temperature;
     return smc->last_temperature_valid;
   }
-  smc->last_sample_time = current_time;
-  smc->sample_attempted = true;
+  smc->last_temperature_sample_time = current_time;
+  smc->temperature_sample_attempted = true;
 
   size_t sample_count = 0;
   for (size_t i = 0; i < smc->temperature_key_count; ++i) {
@@ -315,5 +386,41 @@ bool gpuinfo_apple_smc_get_gpu_temperature(struct gpuinfo_apple_smc *smc, unsign
   smc->last_temperature = average_temperature;
   smc->last_temperature_valid = true;
   *temperature = average_temperature;
+  return true;
+}
+
+bool gpuinfo_apple_smc_get_fan_rpm(struct gpuinfo_apple_smc *smc, unsigned *fan_rpm) {
+  if (!smc || !fan_rpm || !smc->fan_key_count)
+    return false;
+
+  nvtop_time current_time;
+  nvtop_get_current_time(&current_time);
+  if (smc->fan_sample_attempted &&
+      nvtop_difftime_u64(smc->last_fan_sample_time, current_time) < apple_smc_minimum_sample_interval) {
+    if (smc->last_fan_rpm_valid)
+      *fan_rpm = smc->last_fan_rpm;
+    return smc->last_fan_rpm_valid;
+  }
+  smc->last_fan_sample_time = current_time;
+  smc->fan_sample_attempted = true;
+
+  size_t sample_count = 0;
+  for (size_t i = 0; i < smc->fan_key_count; ++i) {
+    uint8_t bytes[32];
+    float sample;
+    if (gpuinfo_apple_smc_read_key(smc, smc->fan_keys[i].key, &smc->fan_keys[i].info, bytes) &&
+        gpuinfo_apple_decode_smc_float(bytes, smc->fan_keys[i].info.data_size, &sample))
+      smc->fan_samples[sample_count++] = sample;
+  }
+
+  unsigned maximum_fan_rpm;
+  if (!gpuinfo_apple_max_fan_rpm(smc->fan_samples, sample_count, &maximum_fan_rpm)) {
+    smc->last_fan_rpm_valid = false;
+    return false;
+  }
+
+  smc->last_fan_rpm = maximum_fan_rpm;
+  smc->last_fan_rpm_valid = true;
+  *fan_rpm = maximum_fan_rpm;
   return true;
 }

--- a/src/extract_gpuinfo_apple_smc.c
+++ b/src/extract_gpuinfo_apple_smc.c
@@ -1,0 +1,319 @@
+/*
+ *
+ * Copyright (C) 2026 NVTOP contributors
+ *
+ * This file is part of Nvtop.
+ *
+ * Nvtop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nvtop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with nvtop.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "extract_gpuinfo_apple_smc.h"
+
+#include "extract_gpuinfo_apple_utils.h"
+#include "nvtop/time.h"
+
+#include <IOKit/IOKitLib.h>
+#include <mach/mach.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <string.h>
+
+// AppleSMC has no public user-space protocol. Keep its wire structures and commands isolated
+// here so changes make temperature unavailable without affecting the other Apple metrics.
+struct apple_smc_version {
+  uint8_t major;
+  uint8_t minor;
+  uint8_t build;
+  uint8_t reserved;
+  uint16_t release;
+};
+
+struct apple_smc_power_limit {
+  uint16_t version;
+  uint16_t length;
+  uint32_t cpu_power_limit;
+  uint32_t gpu_power_limit;
+  uint32_t memory_power_limit;
+};
+
+struct apple_smc_key_info {
+  uint32_t data_size;
+  uint32_t data_type;
+  uint8_t data_attributes;
+};
+
+struct apple_smc_key_data {
+  uint32_t key;
+  struct apple_smc_version version;
+  struct apple_smc_power_limit power_limit;
+  struct apple_smc_key_info key_info;
+  uint8_t result;
+  uint8_t status;
+  uint8_t data8;
+  uint32_t data32;
+  uint8_t bytes[32];
+};
+
+_Static_assert(sizeof(struct apple_smc_version) == 6, "Unexpected AppleSMC version layout");
+_Static_assert(sizeof(struct apple_smc_power_limit) == 16, "Unexpected AppleSMC power limit layout");
+_Static_assert(sizeof(struct apple_smc_key_info) == 12, "Unexpected AppleSMC key info layout");
+_Static_assert(offsetof(struct apple_smc_key_data, bytes) == 48, "Unexpected AppleSMC payload layout");
+_Static_assert(sizeof(struct apple_smc_key_data) == 80, "Unexpected AppleSMC payload size");
+_Static_assert(sizeof(float) == 4, "Unexpected AppleSMC float size");
+
+struct apple_smc_temperature_key {
+  uint32_t key;
+  struct apple_smc_key_info info;
+};
+
+struct gpuinfo_apple_smc {
+  io_connect_t connection;
+  struct apple_smc_temperature_key *temperature_keys;
+  size_t temperature_key_count;
+  float *temperature_samples;
+  nvtop_time last_sample_time;
+  unsigned last_temperature;
+  bool sample_attempted;
+  bool last_temperature_valid;
+};
+
+enum apple_smc_command {
+  apple_smc_command_read_bytes = 5,
+  apple_smc_command_read_key_by_index = 8,
+  apple_smc_command_read_key_info = 9,
+};
+
+static const unsigned apple_smc_user_client_method = 2;
+static const uint64_t apple_smc_minimum_sample_interval = UINT64_C(1000000000);
+
+static uint32_t gpuinfo_apple_smc_key_id(const char name[4]) {
+  return (uint32_t)(uint8_t)name[0] << 24 | (uint32_t)(uint8_t)name[1] << 16 |
+         (uint32_t)(uint8_t)name[2] << 8 | (uint32_t)(uint8_t)name[3];
+}
+
+static bool gpuinfo_apple_smc_call(struct gpuinfo_apple_smc *smc, const struct apple_smc_key_data *input,
+                                   struct apple_smc_key_data *output) {
+  size_t output_size = sizeof(*output);
+  memset(output, 0, sizeof(*output));
+  return IOConnectCallStructMethod(smc->connection, apple_smc_user_client_method, input, sizeof(*input), output,
+                                   &output_size) == kIOReturnSuccess &&
+         output_size == sizeof(*output) && !output->result;
+}
+
+static bool gpuinfo_apple_smc_read_key_info(struct gpuinfo_apple_smc *smc, uint32_t key,
+                                            struct apple_smc_key_info *info) {
+  const struct apple_smc_key_data input = {.key = key, .data8 = apple_smc_command_read_key_info};
+  struct apple_smc_key_data output;
+  if (!gpuinfo_apple_smc_call(smc, &input, &output))
+    return false;
+
+  *info = output.key_info;
+  return true;
+}
+
+static bool gpuinfo_apple_smc_read_key(struct gpuinfo_apple_smc *smc, uint32_t key,
+                                      const struct apple_smc_key_info *info, uint8_t output_bytes[32]) {
+  const struct apple_smc_key_data input = {
+      .key = key, .key_info = *info, .data8 = apple_smc_command_read_bytes};
+  struct apple_smc_key_data output;
+  if (!gpuinfo_apple_smc_call(smc, &input, &output))
+    return false;
+
+  memcpy(output_bytes, output.bytes, sizeof(output.bytes));
+  return true;
+}
+
+static bool gpuinfo_apple_smc_read_key_by_index(struct gpuinfo_apple_smc *smc, uint32_t index, uint32_t *key) {
+  const struct apple_smc_key_data input = {
+      .data8 = apple_smc_command_read_key_by_index, .data32 = index};
+  struct apple_smc_key_data output;
+  if (!gpuinfo_apple_smc_call(smc, &input, &output))
+    return false;
+
+  *key = output.key;
+  return true;
+}
+
+static bool gpuinfo_apple_smc_read_key_count(struct gpuinfo_apple_smc *smc, uint32_t *key_count) {
+  const uint32_t count_key = gpuinfo_apple_smc_key_id("#KEY");
+  struct apple_smc_key_info info;
+  uint8_t bytes[32];
+  if (!gpuinfo_apple_smc_read_key_info(smc, count_key, &info) || info.data_size < 4 ||
+      !gpuinfo_apple_smc_read_key(smc, count_key, &info, bytes))
+    return false;
+
+  *key_count = (uint32_t)bytes[0] << 24 | (uint32_t)bytes[1] << 16 | (uint32_t)bytes[2] << 8 | bytes[3];
+  return *key_count > 0;
+}
+
+static bool gpuinfo_apple_smc_lower_bound(struct gpuinfo_apple_smc *smc, uint32_t key_count, uint32_t target,
+                                          uint32_t *lower_bound) {
+  uint32_t first = 0;
+  uint32_t count = key_count;
+  while (first < count) {
+    const uint32_t middle = first + (count - first) / 2;
+    uint32_t key;
+    if (!gpuinfo_apple_smc_read_key_by_index(smc, middle, &key))
+      return false;
+    if (key < target)
+      first = middle + 1;
+    else
+      count = middle;
+  }
+
+  *lower_bound = first;
+  return true;
+}
+
+static bool gpuinfo_apple_smc_open(struct gpuinfo_apple_smc *smc) {
+  CFMutableDictionaryRef matching_services = IOServiceMatching("AppleSMC");
+  if (!matching_services)
+    return false;
+
+  io_iterator_t services;
+  if (IOServiceGetMatchingServices(kIOMainPortDefault, matching_services, &services) != kIOReturnSuccess)
+    return false;
+
+  for (io_service_t service = IOIteratorNext(services); service; service = IOIteratorNext(services)) {
+    io_name_t name;
+    if (IORegistryEntryGetName(service, name) == kIOReturnSuccess &&
+        strcmp(name, "AppleSMCKeysEndpoint") == 0 &&
+        IOServiceOpen(service, mach_task_self(), 0, &smc->connection) == kIOReturnSuccess) {
+      IOObjectRelease(service);
+      break;
+    }
+    IOObjectRelease(service);
+  }
+  IOObjectRelease(services);
+  return MACH_PORT_VALID(smc->connection);
+}
+
+static bool gpuinfo_apple_smc_discover_temperature_keys(struct gpuinfo_apple_smc *smc) {
+  uint32_t key_count;
+  if (!gpuinfo_apple_smc_read_key_count(smc, &key_count))
+    return false;
+
+  // SMC enumerates keys in lexicographic FourCC order. Locate only the lowercase Tg range
+  // instead of scanning thousands of keys, then validate that ordering while caching the range.
+  const uint32_t first_gpu_temperature_key = gpuinfo_apple_smc_key_id("Tg\0\0");
+  const uint32_t end_gpu_temperature_key = gpuinfo_apple_smc_key_id("Th\0\0");
+  uint32_t first_index, end_index;
+  if (!gpuinfo_apple_smc_lower_bound(smc, key_count, first_gpu_temperature_key, &first_index) ||
+      !gpuinfo_apple_smc_lower_bound(smc, key_count, end_gpu_temperature_key, &end_index) ||
+      first_index >= end_index)
+    return false;
+
+  const size_t maximum_key_count = end_index - first_index;
+  struct apple_smc_temperature_key *keys = calloc(maximum_key_count, sizeof(*keys));
+  if (!keys)
+    return false;
+
+  uint32_t previous_key = 0;
+  size_t valid_key_count = 0;
+  const uint32_t float_type = gpuinfo_apple_smc_key_id("flt ");
+  for (uint32_t index = first_index; index < end_index; ++index) {
+    uint32_t key;
+    if (!gpuinfo_apple_smc_read_key_by_index(smc, index, &key) || key < first_gpu_temperature_key ||
+        key >= end_gpu_temperature_key || (index != first_index && key <= previous_key)) {
+      free(keys);
+      return false;
+    }
+    previous_key = key;
+
+    struct apple_smc_key_info info;
+    if (!gpuinfo_apple_smc_read_key_info(smc, key, &info) || info.data_size != sizeof(float) ||
+        info.data_type != float_type)
+      continue;
+    keys[valid_key_count++] = (struct apple_smc_temperature_key){.key = key, .info = info};
+  }
+
+  if (!valid_key_count) {
+    free(keys);
+    return false;
+  }
+
+  smc->temperature_keys = keys;
+  smc->temperature_key_count = valid_key_count;
+  smc->temperature_samples = calloc(valid_key_count, sizeof(*smc->temperature_samples));
+  if (!smc->temperature_samples)
+    return false;
+  return true;
+}
+
+bool gpuinfo_apple_smc_init(struct gpuinfo_apple_smc **smc) {
+  if (!smc)
+    return false;
+  *smc = NULL;
+
+  struct gpuinfo_apple_smc *new_smc = calloc(1, sizeof(*new_smc));
+  if (!new_smc)
+    return false;
+
+  if (!gpuinfo_apple_smc_open(new_smc) || !gpuinfo_apple_smc_discover_temperature_keys(new_smc)) {
+    gpuinfo_apple_smc_shutdown(new_smc);
+    return false;
+  }
+
+  *smc = new_smc;
+  return true;
+}
+
+void gpuinfo_apple_smc_shutdown(struct gpuinfo_apple_smc *smc) {
+  if (!smc)
+    return;
+
+  if (MACH_PORT_VALID(smc->connection))
+    IOServiceClose(smc->connection);
+  free(smc->temperature_samples);
+  free(smc->temperature_keys);
+  free(smc);
+}
+
+bool gpuinfo_apple_smc_get_gpu_temperature(struct gpuinfo_apple_smc *smc, unsigned *temperature) {
+  if (!smc || !temperature)
+    return false;
+
+  nvtop_time current_time;
+  nvtop_get_current_time(&current_time);
+  if (smc->sample_attempted &&
+      nvtop_difftime_u64(smc->last_sample_time, current_time) < apple_smc_minimum_sample_interval) {
+    if (smc->last_temperature_valid)
+      *temperature = smc->last_temperature;
+    return smc->last_temperature_valid;
+  }
+  smc->last_sample_time = current_time;
+  smc->sample_attempted = true;
+
+  size_t sample_count = 0;
+  for (size_t i = 0; i < smc->temperature_key_count; ++i) {
+    uint8_t bytes[32];
+    float sample;
+    if (gpuinfo_apple_smc_read_key(smc, smc->temperature_keys[i].key, &smc->temperature_keys[i].info, bytes) &&
+        gpuinfo_apple_decode_smc_float(bytes, smc->temperature_keys[i].info.data_size, &sample))
+      smc->temperature_samples[sample_count++] = sample;
+  }
+
+  unsigned average_temperature;
+  if (!gpuinfo_apple_average_temperatures(smc->temperature_samples, sample_count, &average_temperature)) {
+    smc->last_temperature_valid = false;
+    return false;
+  }
+
+  smc->last_temperature = average_temperature;
+  smc->last_temperature_valid = true;
+  *temperature = average_temperature;
+  return true;
+}

--- a/src/extract_gpuinfo_apple_smc.h
+++ b/src/extract_gpuinfo_apple_smc.h
@@ -1,0 +1,33 @@
+/*
+ *
+ * Copyright (C) 2026 NVTOP contributors
+ *
+ * This file is part of Nvtop.
+ *
+ * Nvtop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nvtop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with nvtop.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef EXTRACT_GPUINFO_APPLE_SMC_H_
+#define EXTRACT_GPUINFO_APPLE_SMC_H_
+
+#include <stdbool.h>
+
+struct gpuinfo_apple_smc;
+
+bool gpuinfo_apple_smc_init(struct gpuinfo_apple_smc **smc);
+void gpuinfo_apple_smc_shutdown(struct gpuinfo_apple_smc *smc);
+bool gpuinfo_apple_smc_get_gpu_temperature(struct gpuinfo_apple_smc *smc, unsigned *temperature);
+
+#endif // EXTRACT_GPUINFO_APPLE_SMC_H_

--- a/src/extract_gpuinfo_apple_smc.h
+++ b/src/extract_gpuinfo_apple_smc.h
@@ -29,5 +29,6 @@ struct gpuinfo_apple_smc;
 bool gpuinfo_apple_smc_init(struct gpuinfo_apple_smc **smc);
 void gpuinfo_apple_smc_shutdown(struct gpuinfo_apple_smc *smc);
 bool gpuinfo_apple_smc_get_gpu_temperature(struct gpuinfo_apple_smc *smc, unsigned *temperature);
+bool gpuinfo_apple_smc_get_fan_rpm(struct gpuinfo_apple_smc *smc, unsigned *fan_rpm);
 
 #endif // EXTRACT_GPUINFO_APPLE_SMC_H_

--- a/src/extract_gpuinfo_apple_utils.h
+++ b/src/extract_gpuinfo_apple_utils.h
@@ -26,6 +26,7 @@
 
 #include <CoreFoundation/CoreFoundation.h>
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 #ifdef __cplusplus
@@ -56,6 +57,12 @@ bool gpuinfo_apple_calculate_gpu_usage(uint64_t previous_gpu_time, uint64_t curr
 bool gpuinfo_apple_energy_to_nanojoules(int64_t energy, const char *unit, uint64_t *energy_nanojoules);
 
 bool gpuinfo_apple_calculate_power_draw(uint64_t energy_nanojoules, uint64_t time_elapsed, unsigned *power_draw);
+
+bool gpuinfo_apple_parse_gpu_frequency_states(const uint8_t *data, size_t data_size, unsigned *frequencies,
+                                              size_t frequencies_size, size_t *frequency_count);
+
+bool gpuinfo_apple_calculate_gpu_clock_speed(const uint64_t *residencies, const unsigned *frequencies,
+                                             size_t frequency_count, unsigned *clock_speed);
 
 void gpuinfo_apple_add_process(struct gpu_info *gpu_info, pid_t pid, bool gpu_usage_valid, unsigned gpu_usage);
 

--- a/src/extract_gpuinfo_apple_utils.h
+++ b/src/extract_gpuinfo_apple_utils.h
@@ -69,6 +69,8 @@ bool gpuinfo_apple_decode_smc_float(const uint8_t *data, size_t data_size, float
 bool gpuinfo_apple_average_temperatures(const float *temperatures, size_t temperature_count,
                                         unsigned *average_temperature);
 
+bool gpuinfo_apple_max_fan_rpm(const float *fan_speeds, size_t fan_count, unsigned *fan_rpm);
+
 void gpuinfo_apple_add_process(struct gpu_info *gpu_info, pid_t pid, bool gpu_usage_valid, unsigned gpu_usage);
 
 #ifdef __cplusplus

--- a/src/extract_gpuinfo_apple_utils.h
+++ b/src/extract_gpuinfo_apple_utils.h
@@ -38,6 +38,16 @@ struct gpuinfo_apple_process_sample {
   bool gpu_time_valid;
 };
 
+struct gpuinfo_apple_performance_sample {
+  unsigned gpu_util_rate;
+  uint64_t allocated_system_memory;
+  bool gpu_util_rate_valid;
+  bool allocated_system_memory_valid;
+};
+
+bool gpuinfo_apple_parse_performance_sample(CFDictionaryRef properties,
+                                            struct gpuinfo_apple_performance_sample *sample);
+
 bool gpuinfo_apple_parse_process_sample(CFDictionaryRef properties, struct gpuinfo_apple_process_sample *sample);
 
 bool gpuinfo_apple_calculate_gpu_usage(uint64_t previous_gpu_time, uint64_t current_gpu_time, uint64_t time_elapsed,

--- a/src/extract_gpuinfo_apple_utils.h
+++ b/src/extract_gpuinfo_apple_utils.h
@@ -53,6 +53,10 @@ bool gpuinfo_apple_parse_process_sample(CFDictionaryRef properties, struct gpuin
 bool gpuinfo_apple_calculate_gpu_usage(uint64_t previous_gpu_time, uint64_t current_gpu_time, uint64_t time_elapsed,
                                        unsigned *gpu_usage);
 
+bool gpuinfo_apple_energy_to_nanojoules(int64_t energy, const char *unit, uint64_t *energy_nanojoules);
+
+bool gpuinfo_apple_calculate_power_draw(uint64_t energy_nanojoules, uint64_t time_elapsed, unsigned *power_draw);
+
 void gpuinfo_apple_add_process(struct gpu_info *gpu_info, pid_t pid, bool gpu_usage_valid, unsigned gpu_usage);
 
 #ifdef __cplusplus

--- a/src/extract_gpuinfo_apple_utils.h
+++ b/src/extract_gpuinfo_apple_utils.h
@@ -1,0 +1,52 @@
+/*
+ *
+ * Copyright (C) 2026 NVTOP contributors
+ *
+ * This file is part of Nvtop.
+ *
+ * Nvtop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nvtop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with nvtop.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef EXTRACT_GPUINFO_APPLE_UTILS_H_
+#define EXTRACT_GPUINFO_APPLE_UTILS_H_
+
+#include "nvtop/extract_gpuinfo_common.h"
+
+#include <CoreFoundation/CoreFoundation.h>
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+struct gpuinfo_apple_process_sample {
+  pid_t pid;
+  uint64_t gpu_time;
+  bool gpu_time_valid;
+};
+
+bool gpuinfo_apple_parse_process_sample(CFDictionaryRef properties, struct gpuinfo_apple_process_sample *sample);
+
+bool gpuinfo_apple_calculate_gpu_usage(uint64_t previous_gpu_time, uint64_t current_gpu_time, uint64_t time_elapsed,
+                                       unsigned *gpu_usage);
+
+void gpuinfo_apple_add_process(struct gpu_info *gpu_info, pid_t pid, bool gpu_usage_valid, unsigned gpu_usage);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // EXTRACT_GPUINFO_APPLE_UTILS_H_

--- a/src/extract_gpuinfo_apple_utils.h
+++ b/src/extract_gpuinfo_apple_utils.h
@@ -64,6 +64,11 @@ bool gpuinfo_apple_parse_gpu_frequency_states(const uint8_t *data, size_t data_s
 bool gpuinfo_apple_calculate_gpu_clock_speed(const uint64_t *residencies, const unsigned *frequencies,
                                              size_t frequency_count, unsigned *clock_speed);
 
+bool gpuinfo_apple_decode_smc_float(const uint8_t *data, size_t data_size, float *value);
+
+bool gpuinfo_apple_average_temperatures(const float *temperatures, size_t temperature_count,
+                                        unsigned *average_temperature);
+
 void gpuinfo_apple_add_process(struct gpu_info *gpu_info, pid_t pid, bool gpu_usage_valid, unsigned gpu_usage);
 
 #ifdef __cplusplus

--- a/src/extract_gpuinfo_apple_utils.m
+++ b/src/extract_gpuinfo_apple_utils.m
@@ -118,6 +118,42 @@ bool gpuinfo_apple_calculate_gpu_usage(uint64_t previous_gpu_time, uint64_t curr
   return true;
 }
 
+bool gpuinfo_apple_energy_to_nanojoules(int64_t energy, const char *unit, uint64_t *energy_nanojoules) {
+  if (energy < 0 || !unit || !energy_nanojoules)
+    return false;
+
+  uint64_t multiplier;
+  if (strcmp(unit, "nJ") == 0)
+    multiplier = UINT64_C(1);
+  else if (strcmp(unit, "uJ") == 0)
+    multiplier = UINT64_C(1000);
+  else if (strcmp(unit, "mJ") == 0)
+    multiplier = UINT64_C(1000000);
+  else if (strcmp(unit, "J") == 0)
+    multiplier = UINT64_C(1000000000);
+  else
+    return false;
+
+  if ((uint64_t)energy > UINT64_MAX / multiplier)
+    return false;
+
+  *energy_nanojoules = (uint64_t)energy * multiplier;
+  return true;
+}
+
+bool gpuinfo_apple_calculate_power_draw(uint64_t energy_nanojoules, uint64_t time_elapsed, unsigned *power_draw) {
+  if (!time_elapsed || !power_draw)
+    return false;
+
+  const long double milliwatts =
+      (long double)energy_nanojoules * 1000.0L / (long double)time_elapsed;
+  if (milliwatts > UINT_MAX)
+    return false;
+
+  *power_draw = (unsigned)(milliwatts + 0.5L);
+  return true;
+}
+
 void gpuinfo_apple_add_process(struct gpu_info *gpu_info, pid_t pid, bool gpu_usage_valid, unsigned gpu_usage) {
   struct gpu_process *process = NULL;
   for (unsigned i = 0; i < gpu_info->processes_count; ++i) {

--- a/src/extract_gpuinfo_apple_utils.m
+++ b/src/extract_gpuinfo_apple_utils.m
@@ -242,6 +242,27 @@ bool gpuinfo_apple_average_temperatures(const float *temperatures, size_t temper
   return true;
 }
 
+bool gpuinfo_apple_max_fan_rpm(const float *fan_speeds, size_t fan_count, unsigned *fan_rpm) {
+  if (!fan_speeds || !fan_count || !fan_rpm)
+    return false;
+
+  const float maximum_plausible_fan_rpm = 100000.0f;
+  float maximum_speed = 0;
+  bool valid_speed = false;
+  for (size_t i = 0; i < fan_count; ++i) {
+    if (!isfinite(fan_speeds[i]) || fan_speeds[i] < 0 || fan_speeds[i] > maximum_plausible_fan_rpm)
+      continue;
+    if (!valid_speed || fan_speeds[i] > maximum_speed)
+      maximum_speed = fan_speeds[i];
+    valid_speed = true;
+  }
+  if (!valid_speed)
+    return false;
+
+  *fan_rpm = (unsigned)(maximum_speed + 0.5f);
+  return true;
+}
+
 void gpuinfo_apple_add_process(struct gpu_info *gpu_info, pid_t pid, bool gpu_usage_valid, unsigned gpu_usage) {
   struct gpu_process *process = NULL;
   for (unsigned i = 0; i < gpu_info->processes_count; ++i) {

--- a/src/extract_gpuinfo_apple_utils.m
+++ b/src/extract_gpuinfo_apple_utils.m
@@ -1,0 +1,124 @@
+/*
+ *
+ * Copyright (C) 2026 NVTOP contributors
+ *
+ * This file is part of Nvtop.
+ *
+ * Nvtop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nvtop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with nvtop.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "extract_gpuinfo_apple_utils.h"
+
+#include "nvtop/common.h"
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include <Foundation/Foundation.h>
+#include <limits.h>
+#include <string.h>
+
+bool gpuinfo_apple_parse_process_sample(CFDictionaryRef properties, struct gpuinfo_apple_process_sample *sample) {
+  memset(sample, 0, sizeof(*sample));
+  if (!properties || CFGetTypeID(properties) != CFDictionaryGetTypeID())
+    return false;
+
+  NSDictionary *user_client_info = (__bridge NSDictionary *)properties;
+  id client_creator_info = [user_client_info objectForKey:@"IOUserClientCreator"];
+  if (![client_creator_info isKindOfClass:[NSString class]])
+    return false;
+
+  int pid;
+  const char *client_creator = [client_creator_info UTF8String];
+  // Client creator is in form: pid <pid>, <name>
+  if (!client_creator || sscanf(client_creator, "pid %d,", &pid) != 1 || pid < 0)
+    return false;
+  sample->pid = pid;
+
+  id app_usage = [user_client_info objectForKey:@"AppUsage"];
+  if (![app_usage isKindOfClass:[NSArray class]])
+    return true;
+
+  uint64_t total_gpu_time = 0;
+  for (id app_info in app_usage) {
+    if (![app_info isKindOfClass:[NSDictionary class]])
+      continue;
+
+    id accumulated_gpu_time = [app_info objectForKey:@"accumulatedGPUTime"];
+    if (![accumulated_gpu_time isKindOfClass:[NSNumber class]] || [accumulated_gpu_time longLongValue] < 0)
+      continue;
+
+    const uint64_t gpu_time = [accumulated_gpu_time unsignedLongLongValue];
+    if (UINT64_MAX - total_gpu_time < gpu_time) {
+      sample->gpu_time_valid = false;
+      return true;
+    }
+    total_gpu_time += gpu_time;
+    sample->gpu_time_valid = true;
+  }
+
+  sample->gpu_time = total_gpu_time;
+  return true;
+}
+
+bool gpuinfo_apple_calculate_gpu_usage(uint64_t previous_gpu_time, uint64_t current_gpu_time, uint64_t time_elapsed,
+                                       unsigned *gpu_usage) {
+  if (!time_elapsed || current_gpu_time < previous_gpu_time)
+    return false;
+
+  const uint64_t gpu_time_delta = current_gpu_time - previous_gpu_time;
+  if (gpu_time_delta >= time_elapsed) {
+    *gpu_usage = 100;
+  } else {
+    *gpu_usage = (unsigned)((gpu_time_delta * UINT64_C(100) + time_elapsed / UINT64_C(2)) / time_elapsed);
+  }
+  return true;
+}
+
+void gpuinfo_apple_add_process(struct gpu_info *gpu_info, pid_t pid, bool gpu_usage_valid, unsigned gpu_usage) {
+  struct gpu_process *process = NULL;
+  for (unsigned i = 0; i < gpu_info->processes_count; ++i) {
+    if (gpu_info->processes[i].pid == pid) {
+      process = &gpu_info->processes[i];
+      break;
+    }
+  }
+
+  if (!process) {
+    if (gpu_info->processes_array_size < gpu_info->processes_count + 1) {
+      gpu_info->processes_array_size += COMMON_PROCESS_LINEAR_REALLOC_INC;
+      gpu_info->processes =
+          reallocarray(gpu_info->processes, gpu_info->processes_array_size, sizeof(*gpu_info->processes));
+      if (!gpu_info->processes) {
+        perror("Could not allocate memory: ");
+        exit(EXIT_FAILURE);
+      }
+    }
+
+    process = &gpu_info->processes[gpu_info->processes_count++];
+    RESET_ALL(process->valid);
+    process->pid = pid;
+    process->type = gpu_process_graphical_compute;
+  }
+
+  if (gpu_usage_valid) {
+    if (GPUINFO_PROCESS_FIELD_VALID(process, gpu_usage)) {
+      const unsigned total_usage = process->gpu_usage + gpu_usage;
+      process->gpu_usage = total_usage > 100 ? 100 : total_usage;
+    } else {
+      SET_GPUINFO_PROCESS(process, gpu_usage, gpu_usage);
+    }
+  }
+}

--- a/src/extract_gpuinfo_apple_utils.m
+++ b/src/extract_gpuinfo_apple_utils.m
@@ -28,6 +28,7 @@
 
 #include <Foundation/Foundation.h>
 #include <limits.h>
+#include <math.h>
 #include <string.h>
 
 static bool gpuinfo_apple_get_unsigned_number(id value, uint64_t *number) {
@@ -208,6 +209,36 @@ bool gpuinfo_apple_calculate_gpu_clock_speed(const uint64_t *residencies, const 
     return false;
 
   *clock_speed = (unsigned)(average_frequency + 0.5L);
+  return true;
+}
+
+bool gpuinfo_apple_decode_smc_float(const uint8_t *data, size_t data_size, float *value) {
+  if (!data || data_size != sizeof(float) || !value)
+    return false;
+
+  const uint32_t bits = (uint32_t)data[0] | (uint32_t)data[1] << 8 | (uint32_t)data[2] << 16 |
+                        (uint32_t)data[3] << 24;
+  memcpy(value, &bits, sizeof(*value));
+  return true;
+}
+
+bool gpuinfo_apple_average_temperatures(const float *temperatures, size_t temperature_count,
+                                        unsigned *average_temperature) {
+  if (!temperatures || !temperature_count || !average_temperature)
+    return false;
+
+  long double sum = 0;
+  size_t valid_count = 0;
+  for (size_t i = 0; i < temperature_count; ++i) {
+    if (!isfinite(temperatures[i]) || temperatures[i] <= 0 || temperatures[i] > 150)
+      continue;
+    sum += (long double)temperatures[i];
+    ++valid_count;
+  }
+  if (!valid_count)
+    return false;
+
+  *average_temperature = (unsigned)(sum / valid_count + 0.5L);
   return true;
 }
 

--- a/src/extract_gpuinfo_apple_utils.m
+++ b/src/extract_gpuinfo_apple_utils.m
@@ -154,6 +154,63 @@ bool gpuinfo_apple_calculate_power_draw(uint64_t energy_nanojoules, uint64_t tim
   return true;
 }
 
+static uint32_t gpuinfo_apple_read_little_endian_uint32(const uint8_t *data) {
+  return (uint32_t)data[0] | (uint32_t)data[1] << 8 | (uint32_t)data[2] << 16 | (uint32_t)data[3] << 24;
+}
+
+bool gpuinfo_apple_parse_gpu_frequency_states(const uint8_t *data, size_t data_size, unsigned *frequencies,
+                                              size_t frequencies_size, size_t *frequency_count) {
+  if (!frequency_count)
+    return false;
+  *frequency_count = 0;
+
+  if (!data || !frequencies || data_size < 2 * 8 || data_size % 8)
+    return false;
+
+  const size_t state_count = data_size / 8;
+  if (state_count > frequencies_size)
+    return false;
+
+  // pmgr stores little-endian (frequency Hz, voltage) pairs. The first pair is the OFF state;
+  // subsequent entries align with the active IOReport performance states.
+  for (size_t i = 0; i < state_count; ++i) {
+    const uint32_t frequency_hz = gpuinfo_apple_read_little_endian_uint32(&data[i * 8]);
+    if ((!i && frequency_hz) || (i && frequency_hz < 1000000))
+      return false;
+    frequencies[i] = frequency_hz / 1000000;
+  }
+
+  *frequency_count = state_count;
+  return true;
+}
+
+bool gpuinfo_apple_calculate_gpu_clock_speed(const uint64_t *residencies, const unsigned *frequencies,
+                                             size_t frequency_count, unsigned *clock_speed) {
+  if (!residencies || !frequencies || frequency_count < 2 || frequencies[0] || !clock_speed)
+    return false;
+
+  uint64_t active_residency = 0;
+  long double weighted_frequency = 0;
+  for (size_t i = 1; i < frequency_count; ++i) {
+    if (!frequencies[i] || UINT64_MAX - active_residency < residencies[i])
+      return false;
+    active_residency += residencies[i];
+    weighted_frequency += (long double)residencies[i] * frequencies[i];
+  }
+
+  if (!active_residency) {
+    *clock_speed = 0;
+    return true;
+  }
+
+  const long double average_frequency = weighted_frequency / active_residency;
+  if (average_frequency > UINT_MAX)
+    return false;
+
+  *clock_speed = (unsigned)(average_frequency + 0.5L);
+  return true;
+}
+
 void gpuinfo_apple_add_process(struct gpu_info *gpu_info, pid_t pid, bool gpu_usage_valid, unsigned gpu_usage) {
   struct gpu_process *process = NULL;
   for (unsigned i = 0; i < gpu_info->processes_count; ++i) {

--- a/src/extract_gpuinfo_apple_utils.m
+++ b/src/extract_gpuinfo_apple_utils.m
@@ -30,6 +30,38 @@
 #include <limits.h>
 #include <string.h>
 
+static bool gpuinfo_apple_get_unsigned_number(id value, uint64_t *number) {
+  if (![value isKindOfClass:[NSNumber class]] || [value longLongValue] < 0)
+    return false;
+
+  *number = [value unsignedLongLongValue];
+  return true;
+}
+
+bool gpuinfo_apple_parse_performance_sample(CFDictionaryRef properties,
+                                            struct gpuinfo_apple_performance_sample *sample) {
+  memset(sample, 0, sizeof(*sample));
+  if (!properties || CFGetTypeID(properties) != CFDictionaryGetTypeID())
+    return false;
+
+  NSDictionary *gpu_properties = (__bridge NSDictionary *)properties;
+  id performance_statistics = [gpu_properties objectForKey:@"PerformanceStatistics"];
+  if (![performance_statistics isKindOfClass:[NSDictionary class]])
+    return false;
+
+  uint64_t number;
+  if (gpuinfo_apple_get_unsigned_number([performance_statistics objectForKey:@"Device Utilization %"], &number)) {
+    sample->gpu_util_rate = number > 100 ? 100 : (unsigned)number;
+    sample->gpu_util_rate_valid = true;
+  }
+  if (gpuinfo_apple_get_unsigned_number([performance_statistics objectForKey:@"Alloc system memory"], &number)) {
+    sample->allocated_system_memory = number;
+    sample->allocated_system_memory_valid = true;
+  }
+
+  return true;
+}
+
 bool gpuinfo_apple_parse_process_sample(CFDictionaryRef properties, struct gpuinfo_apple_process_sample *sample) {
   memset(sample, 0, sizeof(*sample));
   if (!properties || CFGetTypeID(properties) != CFDictionaryGetTypeID())
@@ -56,11 +88,10 @@ bool gpuinfo_apple_parse_process_sample(CFDictionaryRef properties, struct gpuin
     if (![app_info isKindOfClass:[NSDictionary class]])
       continue;
 
-    id accumulated_gpu_time = [app_info objectForKey:@"accumulatedGPUTime"];
-    if (![accumulated_gpu_time isKindOfClass:[NSNumber class]] || [accumulated_gpu_time longLongValue] < 0)
+    uint64_t gpu_time;
+    if (!gpuinfo_apple_get_unsigned_number([app_info objectForKey:@"accumulatedGPUTime"], &gpu_time))
       continue;
 
-    const uint64_t gpu_time = [accumulated_gpu_time unsignedLongLongValue];
     if (UINT64_MAX - total_gpu_time < gpu_time) {
       sample->gpu_time_valid = false;
       return true;

--- a/src/get_process_info_mac.c
+++ b/src/get_process_info_mac.c
@@ -21,6 +21,8 @@
 
 #include "nvtop/get_process_info.h"
 
+#include "get_process_info_mac_utils.h"
+
 #include <libproc.h>
 #include <sys/sysctl.h>
 #include <pwd.h>
@@ -28,6 +30,33 @@
 
 #include <string.h>
 #include <stdio.h>
+
+static bool processinfo_mac_is_translated(void) {
+#ifdef __x86_64__
+  int translated = 0;
+  size_t size = sizeof(translated);
+  if (sysctlbyname("sysctl.proc_translated", &translated, &size, NULL, 0) == 0)
+    return translated == 1;
+#endif
+  return false;
+}
+
+static double processinfo_mac_cpu_time_to_seconds(uint64_t mach_ticks) {
+  static mach_timebase_info_data_t timebase;
+  static bool translated;
+  static bool initialized;
+
+  if (!initialized) {
+    if (mach_timebase_info(&timebase) != KERN_SUCCESS) {
+      timebase.numer = 1;
+      timebase.denom = 1;
+    }
+    translated = processinfo_mac_is_translated();
+    initialized = true;
+  }
+
+  return processinfo_mac_time_to_seconds(mach_ticks, translated, timebase.numer, timebase.denom);
+}
 
 void get_username_from_pid(pid_t pid, char **buffer) {
   struct proc_bsdshortinfo proc;
@@ -123,14 +152,8 @@ bool get_process_info(pid_t pid, struct process_cpu_usage *usage) {
 
   nvtop_get_current_time(&usage->timestamp);
 
-  // TODO: Should we implement this workaround?
-  // https://github.com/htop-dev/htop/blob/main/darwin/PlatformHelpers.c#L98
-  mach_timebase_info_data_t info;
-  mach_timebase_info(&info);
-  const double nanoseconds_per_tick = (double)info.numer / (double)info.denom;
-
-  usage->total_user_time = (proc.pti_total_user * nanoseconds_per_tick) / 1000000000.0;
-  usage->total_kernel_time = (proc.pti_total_system * nanoseconds_per_tick) / 1000000000.0;
+  usage->total_user_time = processinfo_mac_cpu_time_to_seconds(proc.pti_total_user);
+  usage->total_kernel_time = processinfo_mac_cpu_time_to_seconds(proc.pti_total_system);
   usage->virtual_memory = proc.pti_virtual_size;
   usage->resident_memory = proc.pti_resident_size;
   return true;

--- a/src/get_process_info_mac_utils.c
+++ b/src/get_process_info_mac_utils.c
@@ -1,0 +1,36 @@
+/*
+ *
+ * Copyright (C) 2026 NVTOP contributors
+ *
+ * This file is part of Nvtop.
+ *
+ * Nvtop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nvtop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with nvtop.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "get_process_info_mac_utils.h"
+
+double processinfo_mac_time_to_seconds(uint64_t mach_ticks, bool translated, uint32_t timebase_numerator,
+                                       uint32_t timebase_denominator) {
+  if (translated) {
+    // Rosetta reports the Intel timebase even though task CPU counters use the Apple Silicon timebase.
+    timebase_numerator = 125;
+    timebase_denominator = 3;
+  }
+  if (!timebase_denominator)
+    return 0.0;
+
+  const double nanoseconds_per_tick = (double)timebase_numerator / (double)timebase_denominator;
+  return (mach_ticks * nanoseconds_per_tick) / 1000000000.0;
+}

--- a/src/get_process_info_mac_utils.h
+++ b/src/get_process_info_mac_utils.h
@@ -1,0 +1,39 @@
+/*
+ *
+ * Copyright (C) 2026 NVTOP contributors
+ *
+ * This file is part of Nvtop.
+ *
+ * Nvtop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nvtop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with nvtop.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#ifndef GET_PROCESS_INFO_MAC_UTILS_H_
+#define GET_PROCESS_INFO_MAC_UTILS_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+double processinfo_mac_time_to_seconds(uint64_t mach_ticks, bool translated, uint32_t timebase_numerator,
+                                       uint32_t timebase_denominator);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // GET_PROCESS_INFO_MAC_UTILS_H_

--- a/src/interface.c
+++ b/src/interface.c
@@ -781,13 +781,13 @@ static void draw_devices(struct list_head *devices, struct nvtop_interface *inte
       mvwprintw(dev->fan_speed, 0, 0, " FAN %3u%%  ",
                 device->dynamic_info.fan_speed > 100 ? 100 : device->dynamic_info.fan_speed);
       mvwchgat(dev->fan_speed, 0, 1, 3, 0, cyan_color, NULL);
-    } else if (device->static_info.integrated_graphics) {
-      mvwprintw(dev->fan_speed, 0, 0, "  CPU-FAN  ");
-      mvwchgat(dev->fan_speed, 0, 2, 7, 0, cyan_color, NULL);
     } else if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, fan_rpm)) {
       mvwprintw(dev->fan_speed, 0, 0, "FAN %4uRPM",
                 device->dynamic_info.fan_rpm > 9999 ? 9999 : device->dynamic_info.fan_rpm);
       mvwchgat(dev->fan_speed, 0, 0, 3, 0, cyan_color, NULL);
+    } else if (device->static_info.integrated_graphics) {
+      mvwprintw(dev->fan_speed, 0, 0, "  CPU-FAN  ");
+      mvwchgat(dev->fan_speed, 0, 2, 7, 0, cyan_color, NULL);
     } else {
       mvwprintw(dev->fan_speed, 0, 0, "  FAN N/A  ");
       mvwchgat(dev->fan_speed, 0, 2, 3, 0, cyan_color, NULL);

--- a/src/interface.c
+++ b/src/interface.c
@@ -821,7 +821,7 @@ static void draw_devices(struct list_head *devices, struct nvtop_interface *inte
                 device->dynamic_info.power_draw_max / 1000);
     else if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, power_draw) &&
              !GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, power_draw_max))
-      mvwprintw(dev->power_info, 0, 0, "POW %3u W", device->dynamic_info.power_draw / 1000);
+      mvwprintw(dev->power_info, 0, 0, "POW %5.1f W", device->dynamic_info.power_draw / 1000.0);
     else if (!GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, power_draw) &&
              GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, power_draw_max))
       mvwprintw(dev->power_info, 0, 0, "POW N/A / %3u W", device->dynamic_info.power_draw_max / 1000);
@@ -2211,7 +2211,8 @@ void print_snapshot(struct list_head *devices, bool use_fahrenheit_option, bool 
 
     // Power draw
     if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, power_draw))
-      printf("%s\"%s\": \"%uW\",\n", indent_level_four, power_field, device->dynamic_info.power_draw / 1000);
+      printf("%s\"%s\": \"%.1fW\",\n", indent_level_four, power_field,
+             device->dynamic_info.power_draw / 1000.0);
     else
       printf("%s\"%s\": null,\n", indent_level_four, power_field);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -28,6 +28,21 @@ if (BUILD_TESTING AND GTest_FOUND)
   target_link_libraries(interfaceTests PRIVATE testLib GTest::gtest_main)
   gtest_discover_tests(interfaceTests)
 
+  if(APPLE)
+    add_executable(
+      appleTests
+      appleTests.mm
+      ${PROJECT_SOURCE_DIR}/src/extract_gpuinfo_apple_utils.m
+    )
+    target_include_directories(appleTests PRIVATE
+      ${PROJECT_SOURCE_DIR}/include
+      ${PROJECT_SOURCE_DIR}/src
+      ${PROJECT_BINARY_DIR}/include)
+    target_link_libraries(appleTests PRIVATE GTest::gtest_main
+      "-framework Foundation")
+    gtest_discover_tests(appleTests)
+  endif()
+
   if (THOROUGH_TESTING)
     target_compile_definitions(interfaceTests PRIVATE THOROUGH_TESTING)
   endif()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -33,6 +33,7 @@ if (BUILD_TESTING AND GTest_FOUND)
       appleTests
       appleTests.mm
       ${PROJECT_SOURCE_DIR}/src/extract_gpuinfo_apple_utils.m
+      ${PROJECT_SOURCE_DIR}/src/get_process_info_mac_utils.c
     )
     target_include_directories(appleTests PRIVATE
       ${PROJECT_SOURCE_DIR}/include

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -6,10 +6,16 @@ if (BUILD_TESTING AND GTest_FOUND)
   # Create a library for testing
   add_library(testLib
     ${PROJECT_SOURCE_DIR}/src/interface_layout_selection.c
-    ${PROJECT_SOURCE_DIR}/src/extract_processinfo_fdinfo.c
     ${PROJECT_SOURCE_DIR}/src/interface_options.c
     ${PROJECT_SOURCE_DIR}/src/ini.c
   )
+  if(APPLE)
+    target_sources(testLib PRIVATE
+      ${PROJECT_SOURCE_DIR}/src/extract_processinfo_mac.c)
+  else()
+    target_sources(testLib PRIVATE
+      ${PROJECT_SOURCE_DIR}/src/extract_processinfo_fdinfo.c)
+  endif()
   target_include_directories(testLib PUBLIC
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_BINARY_DIR}/include)

--- a/tests/appleTests.mm
+++ b/tests/appleTests.mm
@@ -25,6 +25,60 @@
 #include <gtest/gtest.h>
 #include <stdlib.h>
 
+TEST(AppleDynamicInfo, ParsesPerformanceStatistics) {
+  @autoreleasepool {
+    NSDictionary *properties = @{
+      @"PerformanceStatistics" : @{
+        @"Device Utilization %" : @42,
+        @"Alloc system memory" : @123456,
+      },
+    };
+    struct gpuinfo_apple_performance_sample sample;
+
+    ASSERT_TRUE(gpuinfo_apple_parse_performance_sample((__bridge CFDictionaryRef)properties, &sample));
+    EXPECT_TRUE(sample.gpu_util_rate_valid);
+    EXPECT_EQ(sample.gpu_util_rate, 42u);
+    EXPECT_TRUE(sample.allocated_system_memory_valid);
+    EXPECT_EQ(sample.allocated_system_memory, 123456u);
+  }
+}
+
+TEST(AppleDynamicInfo, RejectsMissingOrMalformedStatistics) {
+  @autoreleasepool {
+    NSArray *invalid_properties = @[
+      @{},
+      @{@"PerformanceStatistics" : @42},
+    ];
+    struct gpuinfo_apple_performance_sample sample;
+
+    for (NSDictionary *properties in invalid_properties)
+      EXPECT_FALSE(gpuinfo_apple_parse_performance_sample((__bridge CFDictionaryRef)properties, &sample));
+  }
+}
+
+TEST(AppleDynamicInfo, IgnoresMalformedValuesAndCapsUtilization) {
+  @autoreleasepool {
+    NSDictionary *malformed_values = @{
+      @"PerformanceStatistics" : @{
+        @"Device Utilization %" : @"not a number",
+        @"Alloc system memory" : @(-1),
+      },
+    };
+    NSDictionary *excessive_utilization = @{
+      @"PerformanceStatistics" : @{@"Device Utilization %" : @125},
+    };
+    struct gpuinfo_apple_performance_sample sample;
+
+    ASSERT_TRUE(gpuinfo_apple_parse_performance_sample((__bridge CFDictionaryRef)malformed_values, &sample));
+    EXPECT_FALSE(sample.gpu_util_rate_valid);
+    EXPECT_FALSE(sample.allocated_system_memory_valid);
+
+    ASSERT_TRUE(gpuinfo_apple_parse_performance_sample((__bridge CFDictionaryRef)excessive_utilization, &sample));
+    EXPECT_TRUE(sample.gpu_util_rate_valid);
+    EXPECT_EQ(sample.gpu_util_rate, 100u);
+  }
+}
+
 TEST(AppleProcessInfo, ParsesAndSumsAppUsage) {
   @autoreleasepool {
     NSDictionary *properties = @{

--- a/tests/appleTests.mm
+++ b/tests/appleTests.mm
@@ -24,6 +24,7 @@
 
 #include <Foundation/Foundation.h>
 #include <gtest/gtest.h>
+#include <limits.h>
 #include <stdlib.h>
 
 TEST(AppleProcessCpuInfo, ConvertsNativeMachTicksToSeconds) {
@@ -102,6 +103,48 @@ TEST(AppleDynamicInfo, IgnoresMalformedValuesAndCapsUtilization) {
     EXPECT_TRUE(sample.gpu_util_rate_valid);
     EXPECT_EQ(sample.gpu_util_rate, 100u);
   }
+}
+
+TEST(ApplePowerInfo, ConvertsEnergyUnitsToNanojoules) {
+  uint64_t energy;
+
+  ASSERT_TRUE(gpuinfo_apple_energy_to_nanojoules(42, "nJ", &energy));
+  EXPECT_EQ(energy, 42u);
+  ASSERT_TRUE(gpuinfo_apple_energy_to_nanojoules(42, "uJ", &energy));
+  EXPECT_EQ(energy, 42000u);
+  ASSERT_TRUE(gpuinfo_apple_energy_to_nanojoules(42, "mJ", &energy));
+  EXPECT_EQ(energy, 42000000u);
+  ASSERT_TRUE(gpuinfo_apple_energy_to_nanojoules(42, "J", &energy));
+  EXPECT_EQ(energy, 42000000000u);
+}
+
+TEST(ApplePowerInfo, RejectsInvalidEnergyValues) {
+  uint64_t energy;
+
+  EXPECT_FALSE(gpuinfo_apple_energy_to_nanojoules(-1, "nJ", &energy));
+  EXPECT_FALSE(gpuinfo_apple_energy_to_nanojoules(1, "watts", &energy));
+  EXPECT_FALSE(gpuinfo_apple_energy_to_nanojoules(INT64_MAX, "J", &energy));
+  EXPECT_FALSE(gpuinfo_apple_energy_to_nanojoules(1, NULL, &energy));
+  EXPECT_FALSE(gpuinfo_apple_energy_to_nanojoules(1, "nJ", NULL));
+}
+
+TEST(ApplePowerInfo, CalculatesPowerDrawFromEnergyDelta) {
+  unsigned power_draw;
+
+  ASSERT_TRUE(gpuinfo_apple_calculate_power_draw(5000000, 1000000000, &power_draw));
+  EXPECT_EQ(power_draw, 5u);
+  ASSERT_TRUE(gpuinfo_apple_calculate_power_draw(1500000, 1000000000, &power_draw));
+  EXPECT_EQ(power_draw, 2u);
+  ASSERT_TRUE(gpuinfo_apple_calculate_power_draw(0, 1000000000, &power_draw));
+  EXPECT_EQ(power_draw, 0u);
+}
+
+TEST(ApplePowerInfo, RejectsInvalidPowerSamples) {
+  unsigned power_draw;
+
+  EXPECT_FALSE(gpuinfo_apple_calculate_power_draw(1, 0, &power_draw));
+  EXPECT_FALSE(gpuinfo_apple_calculate_power_draw(UINT64_MAX, 1, &power_draw));
+  EXPECT_FALSE(gpuinfo_apple_calculate_power_draw(1, 1, NULL));
 }
 
 TEST(AppleProcessInfo, ParsesAndSumsAppUsage) {

--- a/tests/appleTests.mm
+++ b/tests/appleTests.mm
@@ -20,10 +20,20 @@
  */
 
 #include "extract_gpuinfo_apple_utils.h"
+#include "get_process_info_mac_utils.h"
 
 #include <Foundation/Foundation.h>
 #include <gtest/gtest.h>
 #include <stdlib.h>
+
+TEST(AppleProcessCpuInfo, ConvertsNativeMachTicksToSeconds) {
+  EXPECT_DOUBLE_EQ(processinfo_mac_time_to_seconds(1000000000, false, 1, 1), 1.0);
+  EXPECT_DOUBLE_EQ(processinfo_mac_time_to_seconds(24000000, false, 125, 3), 1.0);
+}
+
+TEST(AppleProcessCpuInfo, UsesNativeTimebaseUnderRosetta) {
+  EXPECT_DOUBLE_EQ(processinfo_mac_time_to_seconds(24000000, true, 1, 1), 1.0);
+}
 
 TEST(AppleDynamicInfo, ParsesPerformanceStatistics) {
   @autoreleasepool {

--- a/tests/appleTests.mm
+++ b/tests/appleTests.mm
@@ -147,6 +147,72 @@ TEST(ApplePowerInfo, RejectsInvalidPowerSamples) {
   EXPECT_FALSE(gpuinfo_apple_calculate_power_draw(1, 1, NULL));
 }
 
+TEST(AppleClockInfo, ParsesGpuFrequencyStates) {
+  const uint8_t voltage_states[] = {
+      0x00, 0x00, 0x00, 0x00, 0x7d, 0x00, 0x00, 0x00,
+      0x00, 0x65, 0xcd, 0x1d, 0xbc, 0x02, 0x00, 0x00,
+      0x00, 0xca, 0x9a, 0x3b, 0x84, 0x03, 0x00, 0x00,
+      0x00, 0x2f, 0x68, 0x59, 0x4c, 0x04, 0x00, 0x00,
+  };
+  unsigned frequencies[4];
+  size_t frequency_count;
+
+  ASSERT_TRUE(gpuinfo_apple_parse_gpu_frequency_states(
+      voltage_states, sizeof(voltage_states), frequencies, 4, &frequency_count));
+  ASSERT_EQ(frequency_count, 4u);
+  EXPECT_EQ(frequencies[0], 0u);
+  EXPECT_EQ(frequencies[1], 500u);
+  EXPECT_EQ(frequencies[2], 1000u);
+  EXPECT_EQ(frequencies[3], 1500u);
+}
+
+TEST(AppleClockInfo, RejectsMalformedGpuFrequencyStates) {
+  const uint8_t voltage_states[] = {
+      0x00, 0x00, 0x00, 0x00, 0x7d, 0x00, 0x00, 0x00,
+      0x00, 0x65, 0xcd, 0x1d, 0xbc, 0x02, 0x00, 0x00,
+  };
+  unsigned frequencies[2];
+  size_t frequency_count;
+
+  EXPECT_FALSE(gpuinfo_apple_parse_gpu_frequency_states(
+      voltage_states, sizeof(voltage_states) - 1, frequencies, 2, &frequency_count));
+  EXPECT_FALSE(gpuinfo_apple_parse_gpu_frequency_states(
+      voltage_states, sizeof(voltage_states), frequencies, 1, &frequency_count));
+  EXPECT_FALSE(gpuinfo_apple_parse_gpu_frequency_states(
+      voltage_states, sizeof(voltage_states), frequencies, 2, NULL));
+}
+
+TEST(AppleClockInfo, CalculatesActiveResidencyWeightedClockSpeed) {
+  const unsigned frequencies[] = {0, 500, 1000, 1500};
+  const uint64_t residencies[] = {1000, 100, 300, 600};
+  unsigned clock_speed;
+
+  ASSERT_TRUE(gpuinfo_apple_calculate_gpu_clock_speed(
+      residencies, frequencies, 4, &clock_speed));
+  EXPECT_EQ(clock_speed, 1250u);
+}
+
+TEST(AppleClockInfo, ReportsZeroWhenGpuRemainsOff) {
+  const unsigned frequencies[] = {0, 500, 1000};
+  const uint64_t residencies[] = {1000, 0, 0};
+  unsigned clock_speed;
+
+  ASSERT_TRUE(gpuinfo_apple_calculate_gpu_clock_speed(
+      residencies, frequencies, 3, &clock_speed));
+  EXPECT_EQ(clock_speed, 0u);
+}
+
+TEST(AppleClockInfo, RejectsInvalidResidencyTables) {
+  const unsigned frequencies[] = {0, 500};
+  const uint64_t residencies[] = {1000, 100};
+  unsigned clock_speed;
+
+  EXPECT_FALSE(gpuinfo_apple_calculate_gpu_clock_speed(NULL, frequencies, 2, &clock_speed));
+  EXPECT_FALSE(gpuinfo_apple_calculate_gpu_clock_speed(residencies, NULL, 2, &clock_speed));
+  EXPECT_FALSE(gpuinfo_apple_calculate_gpu_clock_speed(residencies, frequencies, 1, &clock_speed));
+  EXPECT_FALSE(gpuinfo_apple_calculate_gpu_clock_speed(residencies, frequencies, 2, NULL));
+}
+
 TEST(AppleProcessInfo, ParsesAndSumsAppUsage) {
   @autoreleasepool {
     NSDictionary *properties = @{

--- a/tests/appleTests.mm
+++ b/tests/appleTests.mm
@@ -25,6 +25,7 @@
 #include <Foundation/Foundation.h>
 #include <gtest/gtest.h>
 #include <limits.h>
+#include <math.h>
 #include <stdlib.h>
 
 TEST(AppleProcessCpuInfo, ConvertsNativeMachTicksToSeconds) {
@@ -211,6 +212,43 @@ TEST(AppleClockInfo, RejectsInvalidResidencyTables) {
   EXPECT_FALSE(gpuinfo_apple_calculate_gpu_clock_speed(residencies, NULL, 2, &clock_speed));
   EXPECT_FALSE(gpuinfo_apple_calculate_gpu_clock_speed(residencies, frequencies, 1, &clock_speed));
   EXPECT_FALSE(gpuinfo_apple_calculate_gpu_clock_speed(residencies, frequencies, 2, NULL));
+}
+
+TEST(AppleTemperatureInfo, DecodesSmcFloat) {
+  const uint8_t encoded_temperature[] = {0x00, 0x00, 0x43, 0x42};
+  float temperature;
+
+  ASSERT_TRUE(gpuinfo_apple_decode_smc_float(encoded_temperature, sizeof(encoded_temperature), &temperature));
+  EXPECT_FLOAT_EQ(temperature, 48.75f);
+}
+
+TEST(AppleTemperatureInfo, RejectsMalformedSmcFloat) {
+  const uint8_t encoded_temperature[] = {0x00, 0x00, 0x43, 0x42};
+  float temperature;
+
+  EXPECT_FALSE(gpuinfo_apple_decode_smc_float(NULL, sizeof(encoded_temperature), &temperature));
+  EXPECT_FALSE(gpuinfo_apple_decode_smc_float(encoded_temperature, sizeof(encoded_temperature) - 1, &temperature));
+  EXPECT_FALSE(gpuinfo_apple_decode_smc_float(encoded_temperature, sizeof(encoded_temperature), NULL));
+}
+
+TEST(AppleTemperatureInfo, AveragesValidGpuSensors) {
+  const float temperatures[] = {46.25f, 47.25f, 0.0f, -1.0f, 151.0f, NAN, INFINITY};
+  unsigned average_temperature;
+
+  ASSERT_TRUE(gpuinfo_apple_average_temperatures(
+      temperatures, sizeof(temperatures) / sizeof(temperatures[0]), &average_temperature));
+  EXPECT_EQ(average_temperature, 47u);
+}
+
+TEST(AppleTemperatureInfo, RejectsMissingValidGpuSensors) {
+  const float invalid_temperatures[] = {0.0f, -1.0f, 151.0f, NAN, INFINITY};
+  unsigned average_temperature;
+
+  EXPECT_FALSE(gpuinfo_apple_average_temperatures(
+      invalid_temperatures, sizeof(invalid_temperatures) / sizeof(invalid_temperatures[0]), &average_temperature));
+  EXPECT_FALSE(gpuinfo_apple_average_temperatures(NULL, 1, &average_temperature));
+  EXPECT_FALSE(gpuinfo_apple_average_temperatures(invalid_temperatures, 0, &average_temperature));
+  EXPECT_FALSE(gpuinfo_apple_average_temperatures(invalid_temperatures, 1, NULL));
 }
 
 TEST(AppleProcessInfo, ParsesAndSumsAppUsage) {

--- a/tests/appleTests.mm
+++ b/tests/appleTests.mm
@@ -43,6 +43,21 @@ TEST(AppleDynamicInfo, ParsesPerformanceStatistics) {
   }
 }
 
+TEST(AppleDynamicInfo, DoesNotSubstituteInUseMemoryCounters) {
+  @autoreleasepool {
+    NSDictionary *properties = @{
+      @"PerformanceStatistics" : @{
+        @"In use system memory" : @654321,
+        @"In use system memory (driver)" : @111111,
+      },
+    };
+    struct gpuinfo_apple_performance_sample sample;
+
+    ASSERT_TRUE(gpuinfo_apple_parse_performance_sample((__bridge CFDictionaryRef)properties, &sample));
+    EXPECT_FALSE(sample.allocated_system_memory_valid);
+  }
+}
+
 TEST(AppleDynamicInfo, RejectsMissingOrMalformedStatistics) {
   @autoreleasepool {
     NSArray *invalid_properties = @[

--- a/tests/appleTests.mm
+++ b/tests/appleTests.mm
@@ -251,6 +251,33 @@ TEST(AppleTemperatureInfo, RejectsMissingValidGpuSensors) {
   EXPECT_FALSE(gpuinfo_apple_average_temperatures(invalid_temperatures, 1, NULL));
 }
 
+TEST(AppleFanInfo, SelectsHighestValidFanSpeed) {
+  const float fan_speeds[] = {1200.25f, 1350.75f, 0.0f, -1.0f, NAN, INFINITY};
+  unsigned fan_rpm;
+
+  ASSERT_TRUE(gpuinfo_apple_max_fan_rpm(fan_speeds, sizeof(fan_speeds) / sizeof(fan_speeds[0]), &fan_rpm));
+  EXPECT_EQ(fan_rpm, 1351u);
+}
+
+TEST(AppleFanInfo, AcceptsStoppedFans) {
+  const float fan_speeds[] = {0.0f, -1.0f, NAN};
+  unsigned fan_rpm;
+
+  ASSERT_TRUE(gpuinfo_apple_max_fan_rpm(fan_speeds, sizeof(fan_speeds) / sizeof(fan_speeds[0]), &fan_rpm));
+  EXPECT_EQ(fan_rpm, 0u);
+}
+
+TEST(AppleFanInfo, RejectsMissingValidFanSpeeds) {
+  const float invalid_fan_speeds[] = {-1.0f, 100001.0f, NAN, INFINITY};
+  unsigned fan_rpm;
+
+  EXPECT_FALSE(gpuinfo_apple_max_fan_rpm(
+      invalid_fan_speeds, sizeof(invalid_fan_speeds) / sizeof(invalid_fan_speeds[0]), &fan_rpm));
+  EXPECT_FALSE(gpuinfo_apple_max_fan_rpm(NULL, 1, &fan_rpm));
+  EXPECT_FALSE(gpuinfo_apple_max_fan_rpm(invalid_fan_speeds, 0, &fan_rpm));
+  EXPECT_FALSE(gpuinfo_apple_max_fan_rpm(invalid_fan_speeds, 1, NULL));
+}
+
 TEST(AppleProcessInfo, ParsesAndSumsAppUsage) {
   @autoreleasepool {
     NSDictionary *properties = @{

--- a/tests/appleTests.mm
+++ b/tests/appleTests.mm
@@ -1,0 +1,145 @@
+/*
+ *
+ * Copyright (C) 2026 NVTOP contributors
+ *
+ * This file is part of Nvtop.
+ *
+ * Nvtop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nvtop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with nvtop.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ */
+
+#include "extract_gpuinfo_apple_utils.h"
+
+#include <Foundation/Foundation.h>
+#include <gtest/gtest.h>
+#include <stdlib.h>
+
+TEST(AppleProcessInfo, ParsesAndSumsAppUsage) {
+  @autoreleasepool {
+    NSDictionary *properties = @{
+      @"IOUserClientCreator" : @"pid 42, test",
+      @"AppUsage" : @[
+        @{@"API" : @"Metal", @"accumulatedGPUTime" : @125},
+        @{@"API" : @"GL/CL", @"accumulatedGPUTime" : @75},
+        @{@"API" : @"Metal", @"accumulatedGPUTime" : @0},
+      ],
+    };
+    struct gpuinfo_apple_process_sample sample;
+
+    ASSERT_TRUE(gpuinfo_apple_parse_process_sample((__bridge CFDictionaryRef)properties, &sample));
+    EXPECT_EQ(sample.pid, 42);
+    EXPECT_TRUE(sample.gpu_time_valid);
+    EXPECT_EQ(sample.gpu_time, 200u);
+  }
+}
+
+TEST(AppleProcessInfo, PreservesPidWhenAppUsageIsUnavailable) {
+  @autoreleasepool {
+    NSDictionary *missing_usage = @{@"IOUserClientCreator" : @"pid 7, test"};
+    NSDictionary *empty_usage = @{@"IOUserClientCreator" : @"pid 8, test", @"AppUsage" : @[]};
+    struct gpuinfo_apple_process_sample sample;
+
+    ASSERT_TRUE(gpuinfo_apple_parse_process_sample((__bridge CFDictionaryRef)missing_usage, &sample));
+    EXPECT_EQ(sample.pid, 7);
+    EXPECT_FALSE(sample.gpu_time_valid);
+
+    ASSERT_TRUE(gpuinfo_apple_parse_process_sample((__bridge CFDictionaryRef)empty_usage, &sample));
+    EXPECT_EQ(sample.pid, 8);
+    EXPECT_FALSE(sample.gpu_time_valid);
+  }
+}
+
+TEST(AppleProcessInfo, IgnoresMalformedAppUsageEntries) {
+  @autoreleasepool {
+    NSDictionary *properties = @{
+      @"IOUserClientCreator" : @"pid 42, test",
+      @"AppUsage" : @[
+        @"not a dictionary",
+        @{@"accumulatedGPUTime" : @"not a number"},
+        @{@"accumulatedGPUTime" : @(-1)},
+        @{@"accumulatedGPUTime" : @25},
+      ],
+    };
+    struct gpuinfo_apple_process_sample sample;
+
+    ASSERT_TRUE(gpuinfo_apple_parse_process_sample((__bridge CFDictionaryRef)properties, &sample));
+    EXPECT_TRUE(sample.gpu_time_valid);
+    EXPECT_EQ(sample.gpu_time, 25u);
+  }
+}
+
+TEST(AppleProcessInfo, RejectsMalformedCreator) {
+  @autoreleasepool {
+    NSArray *invalid_properties = @[
+      @{},
+      @{@"IOUserClientCreator" : @42},
+      @{@"IOUserClientCreator" : @"test"},
+      @{@"IOUserClientCreator" : @"pid -1, test"},
+    ];
+    struct gpuinfo_apple_process_sample sample;
+
+    for (NSDictionary *properties in invalid_properties)
+      EXPECT_FALSE(gpuinfo_apple_parse_process_sample((__bridge CFDictionaryRef)properties, &sample));
+  }
+}
+
+TEST(AppleProcessInfo, CalculatesGpuUsageFromCounterDelta) {
+  unsigned gpu_usage;
+
+  ASSERT_TRUE(gpuinfo_apple_calculate_gpu_usage(100, 350, 1000, &gpu_usage));
+  EXPECT_EQ(gpu_usage, 25u);
+
+  ASSERT_TRUE(gpuinfo_apple_calculate_gpu_usage(350, 350, 1000, &gpu_usage));
+  EXPECT_EQ(gpu_usage, 0u);
+
+  ASSERT_TRUE(gpuinfo_apple_calculate_gpu_usage(100, 1200, 1000, &gpu_usage));
+  EXPECT_EQ(gpu_usage, 100u);
+}
+
+TEST(AppleProcessInfo, RejectsInvalidCounterDeltas) {
+  unsigned gpu_usage;
+
+  EXPECT_FALSE(gpuinfo_apple_calculate_gpu_usage(350, 100, 1000, &gpu_usage));
+  EXPECT_FALSE(gpuinfo_apple_calculate_gpu_usage(100, 350, 0, &gpu_usage));
+}
+
+TEST(AppleProcessInfo, AggregatesClientsByPid) {
+  struct gpu_info gpu_info = {};
+
+  gpuinfo_apple_add_process(&gpu_info, 42, true, 25);
+  gpuinfo_apple_add_process(&gpu_info, 42, true, 35);
+  gpuinfo_apple_add_process(&gpu_info, 7, false, 0);
+
+  ASSERT_EQ(gpu_info.processes_count, 2u);
+  EXPECT_EQ(gpu_info.processes[0].pid, 42);
+  EXPECT_EQ(gpu_info.processes[0].type, gpu_process_graphical_compute);
+  EXPECT_TRUE(GPUINFO_PROCESS_FIELD_VALID(&gpu_info.processes[0], gpu_usage));
+  EXPECT_EQ(gpu_info.processes[0].gpu_usage, 60u);
+  EXPECT_EQ(gpu_info.processes[1].pid, 7);
+  EXPECT_FALSE(GPUINFO_PROCESS_FIELD_VALID(&gpu_info.processes[1], gpu_usage));
+
+  free(gpu_info.processes);
+}
+
+TEST(AppleProcessInfo, CapsAggregatedUsageAtOneHundredPercent) {
+  struct gpu_info gpu_info = {};
+
+  gpuinfo_apple_add_process(&gpu_info, 42, true, 75);
+  gpuinfo_apple_add_process(&gpu_info, 42, true, 50);
+
+  ASSERT_EQ(gpu_info.processes_count, 1u);
+  EXPECT_EQ(gpu_info.processes[0].gpu_usage, 100u);
+
+  free(gpu_info.processes);
+}


### PR DESCRIPTION
## Summary

- make the macOS test suite build reliably, run it in CI, and move platform parsing and sampling logic into focused, testable helpers
- report per-process GPU utilization from AGX client GPU-time deltas while hardening IOKit and process resource handling
- correct process CPU accounting under Rosetta and clarify unified-memory reporting
- add Apple GPU power draw, active-residency-weighted clock speed, GPU temperature, and system fan RPM telemetry, with fractional display for low power values

The Apple-specific telemetry fails gracefully when private IOReport, IOKit, or SMC data is unavailable.

## Testing

- cmake --build build --parallel
- ctest --test-dir build --output-on-failure
- 34 of 34 tests pass on an Apple M5 Max running macOS 26.5.2