### PR TITLE
nvidia: don't report fake PCIe link on unified-memory SoC GPUs

### DIFF
--- a/src/extract_gpuinfo_nvidia.c
+++ b/src/extract_gpuinfo_nvidia.c
@@ -702,14 +702,20 @@ static void gpuinfo_nvidia_refresh_dynamic_info(struct gpu_info *_gpu_info) {
   }
 
   // Pcie generation used by the device
-  last_nvml_return_status = nvmlDeviceGetCurrPcieLinkGeneration(device, &dynamic_info->pcie_link_gen);
-  if (last_nvml_return_status == NVML_SUCCESS)
-    SET_VALID(gpuinfo_pcie_link_gen_valid, dynamic_info->valid);
+  // On unified-memory SoC platforms (e.g. DGX Spark / GB10) the device is not
+  // attached through a PCIe link but via its own on-die interconnect
+  // (NVLink-C2C). NVML still reports placeholder values here (GEN 1 @ 1x) that
+  // would be misleading, so only report them on discrete GPUs.
+  if (!has_unified_memory) {
+    last_nvml_return_status = nvmlDeviceGetCurrPcieLinkGeneration(device, &dynamic_info->pcie_link_gen);
+    if (last_nvml_return_status == NVML_SUCCESS)
+      SET_VALID(gpuinfo_pcie_link_gen_valid, dynamic_info->valid);
 
-  // Pcie width used by the device
-  last_nvml_return_status = nvmlDeviceGetCurrPcieLinkWidth(device, &dynamic_info->pcie_link_width);
-  if (last_nvml_return_status == NVML_SUCCESS)
-    SET_VALID(gpuinfo_pcie_link_width_valid, dynamic_info->valid);
+    // Pcie width used by the device
+    last_nvml_return_status = nvmlDeviceGetCurrPcieLinkWidth(device, &dynamic_info->pcie_link_width);
+    if (last_nvml_return_status == NVML_SUCCESS)
+      SET_VALID(gpuinfo_pcie_link_width_valid, dynamic_info->valid);
+  }
 
   // Pcie reception throughput
   last_nvml_return_status = nvmlDeviceGetPcieThroughput(device, NVML_PCIE_UTIL_RX_BYTES, &dynamic_info->pcie_rx);


### PR DESCRIPTION
## Summary
Fixes the PCIe misreporting portion of **#426** on unified-memory SoC GPUs such as the DGX Spark (GB10).

On the GB10, the GPU is attached via NVLink-C2C (on-die interconnect), not a PCIe slot. However, NVML's `nvmlDeviceGetCurrPcieLinkGeneration` / `nvmlDeviceGetCurrPcieLinkWidth` return `NVML_SUCCESS` with placeholder values (`GEN 1 @ 1x`), which nvtop displayed as if they were a real PCIe link.

These devices are already detected (unified memory → `has_unified_memory`), so this PR gates PCIe link gen/width reporting on **not** being unified memory, making the header fall back to `N/A`. PCIe RX/TX throughput was already `N/A` here because NVML returns `NVML_ERROR_NOT_SUPPORTED` on this platform.

## Before (master)
```
Device 0 [NVIDIA GB10] PCIe GEN 1@ 1x RX: N/A TX: N/A
```

## After
```
Device 0 [NVIDIA GB10] PCIe GEN N/A RX: N/A TX: N/A
```

Memory (`MEM[...Gi]`) is already reported correctly on GB10 via the #466 unified-memory fallback; fan and memory-clock remain correctly `N/A` since the SoC does not expose them through NVML.

## Validation
- Built and tested **on a DGX Spark (GB10, aarch64, driver 580.173.02)**.
- Discrete (non-unified) GPUs are unaffected: `has_unified_memory` is only set when NVML reports unified/SoC memory.