### PR TITLE
Process list: type filter (#294) and secondary sort key (#473)

### DIFF
--- a/include/nvtop/interface_common.h
+++ b/include/nvtop/interface_common.h
@@ -51,6 +51,16 @@ enum process_field {
   process_cpu_mem_usage,
   process_command,
   process_field_count,
+  // Sentinel used to represent "no sorting field" (e.g. no secondary sort key)
+  process_none = process_field_count,
+};
+
+// Filter applied to the displayed process list based on their workload type
+enum process_type_filter {
+  process_type_filter_all = 0,       // Show every process
+  process_type_filter_compute_only,  // Show compute (and compute+graphical) processes only
+  process_type_filter_graphical_only,// Show graphical (and compute+graphical) processes only
+  process_type_filter_count,
 };
 
 typedef int process_field_displayed;

--- a/include/nvtop/interface_internal_common.h
+++ b/include/nvtop/interface_internal_common.h
@@ -88,6 +88,7 @@ struct option_window {
   WINDOW *option_win;
   bool last_key_was_number;
   unsigned int input_number;
+  bool sort_by_secondary_active; // F6 sort window: editing the secondary sort key
 };
 
 struct process_window {

--- a/include/nvtop/interface_options.h
+++ b/include/nvtop/interface_options.h
@@ -43,7 +43,9 @@ typedef struct nvtop_interface_option_struct {
   nvtop_interface_gpu_opts *gpu_specific_opts;      // GPU specific options
   char *config_file_location;                       // Location of the config file
   enum process_field sort_processes_by;             // Specify the field used to order the processes
-  bool sort_descending_order;                       // Sort in descending order
+  enum process_field sort_processes_by_secondary;    // Optional secondary sort field (tie-break), or process_none
+  bool sort_descending_order;                        // Sort in descending order
+  enum process_type_filter process_type_filter;      // Filter the process list by workload type
   int update_interval;                              // Interval between interface update in milliseconds
   process_field_displayed process_fields_displayed; // Which columns of the
                                                     // process list are displayed

--- a/src/interface.c
+++ b/src/interface.c
@@ -947,224 +947,95 @@ static all_processes all_processes_array(struct list_head *devices) {
   return merged_devices_processes;
 }
 
-static int compare_pid_desc(const void *pp1, const void *pp2) {
-  const struct gpuid_and_process *p1 = (const struct gpuid_and_process *)pp1;
-  const struct gpuid_and_process *p2 = (const struct gpuid_and_process *)pp2;
-  return p1->process->pid >= p2->process->pid ? -1 : 1;
-}
-
-static int compare_pid_asc(const void *pp1, const void *pp2) { return compare_pid_desc(pp2, pp1); }
-
-static int compare_username_desc(const void *pp1, const void *pp2) {
-  const struct gpuid_and_process *p1 = (const struct gpuid_and_process *)pp1;
-  const struct gpuid_and_process *p2 = (const struct gpuid_and_process *)pp2;
-  if (GPUINFO_PROCESS_FIELD_VALID(p1->process, user_name) && GPUINFO_PROCESS_FIELD_VALID(p2->process, user_name))
-    return -strcmp(p1->process->user_name, p2->process->user_name);
-  else
+// Lexicographic comparison helpers used for multi-field sorting (#473).
+// Each returns <0, 0, >0 so multiple sort keys can be chained together.
+static int compare_process_field(const struct gpuid_and_process *p1, const struct gpuid_and_process *p2,
+                                 enum process_field field) {
+  switch (field) {
+  case process_pid:
+    return (p1->process->pid > p2->process->pid) - (p1->process->pid < p2->process->pid);
+  case process_user:
+    if (GPUINFO_PROCESS_FIELD_VALID(p1->process, user_name) && GPUINFO_PROCESS_FIELD_VALID(p2->process, user_name))
+      return strcmp(p1->process->user_name, p2->process->user_name);
     return 0;
-}
-
-static int compare_username_asc(const void *pp1, const void *pp2) { return compare_username_desc(pp2, pp1); }
-
-static int compare_process_name_desc(const void *pp1, const void *pp2) {
-  const struct gpuid_and_process *p1 = (const struct gpuid_and_process *)pp1;
-  const struct gpuid_and_process *p2 = (const struct gpuid_and_process *)pp2;
-  if (GPUINFO_PROCESS_FIELD_VALID(p1->process, cmdline) && GPUINFO_PROCESS_FIELD_VALID(p2->process, cmdline))
-    return -strcmp(p1->process->cmdline, p2->process->cmdline);
-  else
+  case process_gpu_id:
+    return (p1->gpu_id > p2->gpu_id) - (p1->gpu_id < p2->gpu_id);
+  case process_type:
+    // Graphical processes are shown before compute ones.
+    return (int)(p1->process->type > p2->process->type) - (int)(p1->process->type < p2->process->type);
+  case process_gpu_rate: {
+    unsigned v1 = GPUINFO_PROCESS_FIELD_VALID(p1->process, gpu_usage) ? p1->process->gpu_usage : 0;
+    unsigned v2 = GPUINFO_PROCESS_FIELD_VALID(p2->process, gpu_usage) ? p2->process->gpu_usage : 0;
+    return (v1 > v2) - (v1 < v2);
+  }
+  case process_enc_rate: {
+    unsigned v1 = GPUINFO_PROCESS_FIELD_VALID(p1->process, encode_usage) ? p1->process->encode_usage : 0;
+    unsigned v2 = GPUINFO_PROCESS_FIELD_VALID(p2->process, encode_usage) ? p2->process->encode_usage : 0;
+    return (v1 > v2) - (v1 < v2);
+  }
+  case process_dec_rate: {
+    unsigned v1 = GPUINFO_PROCESS_FIELD_VALID(p1->process, decode_usage) ? p1->process->decode_usage : 0;
+    unsigned v2 = GPUINFO_PROCESS_FIELD_VALID(p2->process, decode_usage) ? p2->process->decode_usage : 0;
+    return (v1 > v2) - (v1 < v2);
+  }
+  case process_memory: {
+    unsigned long long v1 =
+        GPUINFO_PROCESS_FIELD_VALID(p1->process, gpu_memory_usage) ? p1->process->gpu_memory_usage : 0;
+    unsigned long long v2 =
+        GPUINFO_PROCESS_FIELD_VALID(p2->process, gpu_memory_usage) ? p2->process->gpu_memory_usage : 0;
+    return (v1 > v2) - (v1 < v2);
+  }
+  case process_cpu_usage: {
+    unsigned v1 = GPUINFO_PROCESS_FIELD_VALID(p1->process, cpu_usage) ? p1->process->cpu_usage : 0;
+    unsigned v2 = GPUINFO_PROCESS_FIELD_VALID(p2->process, cpu_usage) ? p2->process->cpu_usage : 0;
+    return (v1 > v2) - (v1 < v2);
+  }
+  case process_cpu_mem_usage: {
+    unsigned long long v1 = GPUINFO_PROCESS_FIELD_VALID(p1->process, cpu_memory_res) ? p1->process->cpu_memory_res : 0;
+    unsigned long long v2 = GPUINFO_PROCESS_FIELD_VALID(p2->process, cpu_memory_res) ? p2->process->cpu_memory_res : 0;
+    return (v1 > v2) - (v1 < v2);
+  }
+  case process_command:
+    if (GPUINFO_PROCESS_FIELD_VALID(p1->process, cmdline) && GPUINFO_PROCESS_FIELD_VALID(p2->process, cmdline))
+      return strcmp(p1->process->cmdline, p2->process->cmdline);
     return 0;
-}
-
-static int compare_process_name_asc(const void *pp1, const void *pp2) { return compare_process_name_desc(pp2, pp1); }
-
-static int compare_mem_usage_desc(const void *pp1, const void *pp2) {
-  const struct gpuid_and_process *p1 = (const struct gpuid_and_process *)pp1;
-  const struct gpuid_and_process *p2 = (const struct gpuid_and_process *)pp2;
-  if (GPUINFO_PROCESS_FIELD_VALID(p1->process, gpu_memory_usage) &&
-      GPUINFO_PROCESS_FIELD_VALID(p2->process, gpu_memory_usage))
-    return p1->process->gpu_memory_usage >= p2->process->gpu_memory_usage ? -1 : 1;
-  else
+  case process_none:
+  default:
     return 0;
-}
-
-static int compare_mem_usage_asc(const void *pp1, const void *pp2) { return compare_mem_usage_desc(pp2, pp1); }
-
-static int compare_cpu_usage_desc(const void *pp1, const void *pp2) {
-  const struct gpuid_and_process *p1 = (const struct gpuid_and_process *)pp1;
-  const struct gpuid_and_process *p2 = (const struct gpuid_and_process *)pp2;
-  if (GPUINFO_PROCESS_FIELD_VALID(p1->process, cpu_usage) && GPUINFO_PROCESS_FIELD_VALID(p2->process, cpu_usage))
-    return p1->process->cpu_usage >= p2->process->cpu_usage ? -1 : 1;
-  else
-    return 0;
-}
-
-static int compare_cpu_usage_asc(const void *pp1, const void *pp2) { return compare_cpu_usage_desc(pp2, pp1); }
-
-static int compare_cpu_mem_usage_desc(const void *pp1, const void *pp2) {
-  const struct gpuid_and_process *p1 = (const struct gpuid_and_process *)pp1;
-  const struct gpuid_and_process *p2 = (const struct gpuid_and_process *)pp2;
-  if (GPUINFO_PROCESS_FIELD_VALID(p1->process, cpu_memory_res) &&
-      GPUINFO_PROCESS_FIELD_VALID(p2->process, cpu_memory_res))
-    return p1->process->cpu_memory_res >= p2->process->cpu_memory_res ? -1 : 1;
-  else
-    return 0;
-}
-
-static int compare_cpu_mem_usage_asc(const void *pp1, const void *pp2) { return compare_cpu_mem_usage_desc(pp2, pp1); }
-
-static int compare_gpu_desc(const void *pp1, const void *pp2) {
-  const struct gpuid_and_process *p1 = (const struct gpuid_and_process *)pp1;
-  const struct gpuid_and_process *p2 = (const struct gpuid_and_process *)pp2;
-  return p1->gpu_id >= p2->gpu_id ? -1 : 1;
-}
-
-static int compare_gpu_asc(const void *pp1, const void *pp2) { return -compare_gpu_desc(pp1, pp2); }
-
-static int compare_process_type_desc(const void *pp1, const void *pp2) {
-  const struct gpuid_and_process *p1 = (const struct gpuid_and_process *)pp1;
-  const struct gpuid_and_process *p2 = (const struct gpuid_and_process *)pp2;
-  return (p1->process->type == gpu_process_graphical) != (p2->process->type == gpu_process_graphical);
-}
-
-static int compare_process_type_asc(const void *pp1, const void *pp2) { return -compare_process_name_desc(pp1, pp2); }
-
-static int compare_process_gpu_rate_desc(const void *pp1, const void *pp2) {
-  const struct gpuid_and_process *p1 = (const struct gpuid_and_process *)pp1;
-  const struct gpuid_and_process *p2 = (const struct gpuid_and_process *)pp2;
-  if (GPUINFO_PROCESS_FIELD_VALID(p1->process, gpu_usage) && GPUINFO_PROCESS_FIELD_VALID(p2->process, gpu_usage)) {
-    return p1->process->gpu_usage > p2->process->gpu_usage ? -1 : 1;
-  } else {
-    if (GPUINFO_PROCESS_FIELD_VALID(p1->process, gpu_usage)) {
-      return p1->process->gpu_usage > 0 ? -1 : 0;
-    } else if (GPUINFO_PROCESS_FIELD_VALID(p2->process, gpu_usage)) {
-      return p2->process->gpu_usage > 0 ? 1 : 0;
-    } else {
-      return 0;
-    }
   }
 }
 
-static int compare_process_gpu_rate_asc(const void *pp1, const void *pp2) {
-  return -compare_process_gpu_rate_desc(pp1, pp2);
-}
+#define MAX_SORT_FIELDS 2
+// Sort context, set right before qsort() since qsort's comparator has no user data.
+static enum process_field sort_context_fields[MAX_SORT_FIELDS];
+static unsigned sort_context_field_count;
+static bool sort_context_ascending;
 
-static int compare_process_enc_rate_desc(const void *pp1, const void *pp2) {
+static int compare_process_multi(const void *pp1, const void *pp2) {
   const struct gpuid_and_process *p1 = (const struct gpuid_and_process *)pp1;
   const struct gpuid_and_process *p2 = (const struct gpuid_and_process *)pp2;
-  if (GPUINFO_PROCESS_FIELD_VALID(p1->process, encode_usage) &&
-      GPUINFO_PROCESS_FIELD_VALID(p2->process, encode_usage)) {
-    return p1->process->encode_usage >= p2->process->encode_usage ? -1 : 1;
-  } else {
-    if (GPUINFO_PROCESS_FIELD_VALID(p1->process, encode_usage)) {
-      return p1->process->encode_usage > 0 ? -1 : 0;
-    } else if (GPUINFO_PROCESS_FIELD_VALID(p2->process, encode_usage)) {
-      return p2->process->encode_usage > 0 ? 1 : 0;
-    } else {
-      return 0;
-    }
+  for (unsigned i = 0; i < sort_context_field_count; ++i) {
+    int cmp = compare_process_field(p1, p2, sort_context_fields[i]);
+    if (cmp != 0)
+      return sort_context_ascending ? cmp : -cmp;
   }
+  return 0;
 }
 
-static int compare_process_enc_rate_asc(const void *pp1, const void *pp2) {
-  return -compare_process_enc_rate_desc(pp1, pp2);
-}
-
-static int compare_process_dec_rate_desc(const void *pp1, const void *pp2) {
-  const struct gpuid_and_process *p1 = (const struct gpuid_and_process *)pp1;
-  const struct gpuid_and_process *p2 = (const struct gpuid_and_process *)pp2;
-  if (GPUINFO_PROCESS_FIELD_VALID(p1->process, decode_usage) &&
-      GPUINFO_PROCESS_FIELD_VALID(p2->process, decode_usage)) {
-    return p1->process->decode_usage >= p2->process->decode_usage ? -1 : 1;
-  } else {
-    if (GPUINFO_PROCESS_FIELD_VALID(p1->process, decode_usage)) {
-      return p1->process->decode_usage > 0 ? -1 : 0;
-    } else if (GPUINFO_PROCESS_FIELD_VALID(p2->process, decode_usage)) {
-      return p2->process->decode_usage > 0 ? 1 : 0;
-    } else {
-      return 0;
-    }
-  }
-}
-static int compare_process_dec_rate_asc(const void *pp1, const void *pp2) {
-  return -compare_process_dec_rate_desc(pp1, pp2);
-}
-
-static void sort_process(all_processes all_procs, enum process_field criterion, bool asc_sort) {
+static void sort_process(all_processes all_procs, enum process_field criterion, enum process_field secondary,
+                         bool asc_sort) {
   if (all_procs.processes_count == 0 || !all_procs.processes)
     return;
-  int (*sort_fun)(const void *, const void *);
-  switch (criterion) {
-  case process_pid:
-    if (asc_sort)
-      sort_fun = compare_pid_asc;
-    else
-      sort_fun = compare_pid_desc;
-    break;
-  case process_user:
-    if (asc_sort)
-      sort_fun = compare_username_asc;
-    else
-      sort_fun = compare_username_desc;
-    break;
-  case process_gpu_id:
-    if (asc_sort)
-      sort_fun = compare_gpu_asc;
-    else
-      sort_fun = compare_gpu_desc;
-    break;
-  case process_type:
-    if (asc_sort)
-      sort_fun = compare_process_type_asc;
-    else
-      sort_fun = compare_process_type_desc;
-    break;
-  case process_memory:
-    if (asc_sort)
-      sort_fun = compare_mem_usage_asc;
-    else
-      sort_fun = compare_mem_usage_desc;
-    break;
-  case process_command:
-    if (asc_sort)
-      sort_fun = compare_process_name_asc;
-    else
-      sort_fun = compare_process_name_desc;
-    break;
-  case process_cpu_usage:
-    if (asc_sort)
-      sort_fun = compare_cpu_usage_asc;
-    else
-      sort_fun = compare_cpu_usage_desc;
-    break;
-  case process_cpu_mem_usage:
-    if (asc_sort)
-      sort_fun = compare_cpu_mem_usage_asc;
-    else
-      sort_fun = compare_cpu_mem_usage_desc;
-    break;
-  case process_gpu_rate:
-    if (asc_sort)
-      sort_fun = compare_process_gpu_rate_asc;
-    else
-      sort_fun = compare_process_gpu_rate_desc;
-    break;
-  case process_enc_rate:
-    if (asc_sort)
-      sort_fun = compare_process_enc_rate_asc;
-    else
-      sort_fun = compare_process_enc_rate_desc;
-    break;
-  case process_dec_rate:
-    if (asc_sort)
-      sort_fun = compare_process_dec_rate_asc;
-    else
-      sort_fun = compare_process_dec_rate_desc;
-    break;
-  case process_field_count:
-    return;
-  }
-  qsort(all_procs.processes, all_procs.processes_count, sizeof(*all_procs.processes), sort_fun);
+
+  sort_context_field_count = 0;
+  sort_context_fields[sort_context_field_count++] = criterion;
+  if (secondary != process_none && secondary != criterion && sort_context_field_count < MAX_SORT_FIELDS)
+    sort_context_fields[sort_context_field_count++] = secondary;
+  sort_context_ascending = asc_sort;
+
+  qsort(all_procs.processes, all_procs.processes_count, sizeof(*all_procs.processes), compare_process_multi);
 }
+
 
 static void filter_out_nvtop_pid(all_processes *all_procs, struct nvtop_interface *interface) {
   if (interface->options.filter_nvtop_pid) {
@@ -1177,6 +1048,25 @@ static void filter_out_nvtop_pid(all_processes *all_procs, struct nvtop_interfac
       }
     }
   }
+}
+
+// Removes processes that do not match the selected workload type filter (#294).
+static void filter_out_proc_type(all_processes *all_procs, enum process_type_filter filter) {
+  if (filter == process_type_filter_all)
+    return;
+  unsigned keep = 0;
+  for (unsigned procId = 0; procId < all_procs->processes_count; ++procId) {
+    enum gpu_process_type type = all_procs->processes[procId].process->type;
+    // Compute-only keeps compute (and compute+graphical); unknown processes are kept
+    // so useful entries are not hidden when the type cannot be determined.
+    bool is_compute = type == gpu_process_compute || type == gpu_process_graphical_compute ||
+                      type == gpu_process_unknown;
+    bool is_graphical = type == gpu_process_graphical || type == gpu_process_graphical_compute;
+    bool keep_proc = (filter == process_type_filter_compute_only) ? is_compute : is_graphical;
+    if (keep_proc)
+      all_procs->processes[keep++] = all_procs->processes[procId];
+  }
+  all_procs->processes_count = keep;
 }
 
 static const char *columnName[process_field_count] = {
@@ -1436,7 +1326,9 @@ static void draw_processes(struct list_head *devices, struct nvtop_interface *in
 
   all_processes all_procs = all_processes_array(devices);
   filter_out_nvtop_pid(&all_procs, interface);
-  sort_process(all_procs, interface->options.sort_processes_by, !interface->options.sort_descending_order);
+  filter_out_proc_type(&all_procs, interface->options.process_type_filter);
+  sort_process(all_procs, interface->options.sort_processes_by, interface->options.sort_processes_by_secondary,
+               !interface->options.sort_descending_order);
 
   if (all_procs.processes_count > 0) {
     if (interface->process.selected_row >= all_procs.processes_count)
@@ -1514,7 +1406,10 @@ static void draw_kill_option(struct nvtop_interface *interface) {
 static void draw_sort_option(struct nvtop_interface *interface) {
   WINDOW *win = interface->process.option_window.option_win;
   wattr_set(win, A_REVERSE, green_color, NULL);
-  mvwprintw(win, 0, 0, "Sort by     ");
+  if (interface->process.option_window.sort_by_secondary_active)
+    mvwprintw(win, 0, 0, "Then by    ");
+  else
+    mvwprintw(win, 0, 0, "Sort by     ");
   wstandend(win);
   wprintw(win, " ");
   int rows, cols;
@@ -1545,7 +1440,10 @@ static void draw_sort_option(struct nvtop_interface *interface) {
         if (option_index + 1 == interface->process.option_window.selected_row) {
           wattr_set(win, A_STANDOUT, cyan_color, NULL);
         }
-        wprintw(win, "%s", columnName[field]);
+        bool is_current = interface->process.option_window.sort_by_secondary_active
+                              ? (field == interface->options.sort_processes_by_secondary)
+                              : (field == interface->options.sort_processes_by);
+        wprintw(win, "%s%s", is_current ? "*" : " ", columnName[field]);
         getyx(win, rows, cols);
         for (unsigned int j = cols; j < option_window_size; ++j)
           wprintw(win, " ");
@@ -1607,6 +1505,7 @@ static const char *option_selection_sort[][2] = {
     {"ESC", "Cancel"},
     {"+", "Ascending"},
     {"-", "Descending"},
+    {"Tab", "Primary/Secondary"},
 };
 
 static const char *option_selection_kill[][2] = {
@@ -1892,7 +1791,10 @@ static void option_change_sort(struct nvtop_interface *interface) {
   for (enum process_field i = process_pid; i < process_field_count; ++i) {
     if (process_is_field_displayed(i, interface->options.process_fields_displayed)) {
       if (index == interface->process.option_window.selected_row - 1) {
-        interface->options.sort_processes_by = i;
+        if (interface->process.option_window.sort_by_secondary_active)
+          interface->options.sort_processes_by_secondary = i;
+        else
+          interface->options.sort_processes_by = i;
         return;
       }
       index++;
@@ -1928,7 +1830,13 @@ void interface_key(int keyId, struct nvtop_interface *interface) {
         interface->process.option_window.state == nvtop_option_state_hidden) {
       interface->process.option_window.state = nvtop_option_state_sort_by;
       interface->process.option_window.selected_row = 0;
+      interface->process.option_window.sort_by_secondary_active = false;
     }
+    break;
+  case '\t':
+    if (interface->process.option_window.state == nvtop_option_state_sort_by)
+      interface->process.option_window.sort_by_secondary_active =
+          !interface->process.option_window.sort_by_secondary_active;
     break;
   case 'l':
   case KEY_RIGHT:

--- a/src/interface_options.c
+++ b/src/interface_options.c
@@ -122,7 +122,9 @@ void alloc_interface_options_internals(char *config_location, unsigned num_devic
   options->temperature_in_fahrenheit = false;
   options->config_file_location = NULL;
   options->sort_processes_by = process_memory;
+  options->sort_processes_by_secondary = process_none;
   options->sort_descending_order = true;
+  options->process_type_filter = process_type_filter_all;
   options->update_interval = 1000;
   options->process_fields_displayed = 0;
   options->has_monitored_set_changed = false;
@@ -189,12 +191,16 @@ static const char process_list_section[] = "ProcessListOption";
 static const char process_hide_nvtop_process_list[] = "HideNvtopProcessList";
 static const char process_hide_nvtop_process[] = "HideNvtopProcess";
 static const char process_value_sortby[] = "SortBy";
+static const char process_value_sortby_secondary[] = "SortBySecondary";
+static const char process_value_process_type_filter[] = "ProcessTypeFilter";
 static const char process_value_display_field[] = "DisplayField";
 static const char *process_sortby_vals[process_field_count + 1] = {
     "pId", "user", "gpuId", "type", "gpuRate", "encRate", "decRate", "memory", "cpuUsage", "cpuMem", "cmdline", "none"};
 static const char process_value_sort_order[] = "SortOrder";
 static const char process_sort_descending[] = "descending";
 static const char process_sort_ascending[] = "ascending";
+
+static const char *process_type_filter_vals[process_type_filter_count] = {"all", "compute", "graphical"};
 
 static const char device_section[] = "Device";
 static const char device_pdev[] = "Pdev";
@@ -295,6 +301,20 @@ static int nvtop_option_ini_handler(void *user, const char *section, const char 
       for (enum process_field i = process_pid; i < process_field_count; ++i) {
         if (strcmp(value, process_sortby_vals[i]) == 0) {
           ini_data->options->sort_processes_by = i;
+        }
+      }
+    }
+    if (strcmp(name, process_value_sortby_secondary) == 0) {
+      for (enum process_field i = process_pid; i < process_field_count + 1; ++i) {
+        if (strcmp(value, process_sortby_vals[i]) == 0) {
+          ini_data->options->sort_processes_by_secondary = i;
+        }
+      }
+    }
+    if (strcmp(name, process_value_process_type_filter) == 0) {
+      for (enum process_type_filter i = process_type_filter_all; i < process_type_filter_count; ++i) {
+        if (strcmp(value, process_type_filter_vals[i]) == 0) {
+          ini_data->options->process_type_filter = i;
         }
       }
     }
@@ -433,6 +453,10 @@ bool save_interface_options_to_config_file(unsigned total_dev_count, const nvtop
   fprintf(config_file, "%s = %s\n", process_value_sort_order,
           options->sort_descending_order ? process_sort_descending : process_sort_ascending);
   fprintf(config_file, "%s = %s\n", process_value_sortby, process_sortby_vals[options->sort_processes_by]);
+  fprintf(config_file, "%s = %s\n", process_value_sortby_secondary,
+          process_sortby_vals[options->sort_processes_by_secondary]);
+  fprintf(config_file, "%s = %s\n", process_value_process_type_filter,
+          process_type_filter_vals[options->process_type_filter]);
   bool display_any_field = false;
   for (enum process_field field = process_pid; field < process_field_count; ++field) {
     if (process_is_field_displayed(field, options->process_fields_displayed)) {

--- a/src/interface_setup_win.c
+++ b/src/interface_setup_win.c
@@ -113,16 +113,23 @@ enum setup_proc_list_options {
   setup_proc_list_hide_nvtop_process,
   setup_proc_list_sort_ascending,
   setup_proc_list_sort_by,
+  setup_proc_list_sort_by_secondary,
+  setup_proc_list_show_only,
   setup_proc_list_display,
   setup_proc_list_options_count
 };
 
 static const char *setup_proc_list_option_description[setup_proc_list_options_count] = {
-    "Don't display the process list", "Hide nvtop in the process list", "Sort Ascending", "Sort by", "Field Displayed"};
+    "Don't display the process list",      "Hide nvtop in the process list",
+    "Sort Ascending",                     "Sort by",
+    "Sort by (then)",                     "Show only process type",
+    "Field Displayed"};
 
 static const char *setup_proc_list_value_descriptions[process_field_count] = {
     "Process Id",    "User name",        "Device Id", "Workload type",    "GPU usage", "Encoder usage",
     "Decoder usage", "GPU memory usage", "CPU usage", "CPU memory usage", "Command"};
+
+static const char *setup_proc_list_filter_values[process_type_filter_count] = {"All", "Compute only", "Graphical only"};
 
 static unsigned int sizeof_setup_windows[setup_window_type_count] = {[setup_window_type_setup] = 11,
                                                                      [setup_window_type_single] = 0,
@@ -495,7 +502,8 @@ static void draw_setup_window_proc_list(struct nvtop_interface *interface) {
       interface->setup_win.indentation_level = 1;
   } else {
     option_list_win = interface->setup_win.split[0];
-    if (interface->setup_win.options_selected[0] == setup_proc_list_sort_by) {
+    if (interface->setup_win.options_selected[0] == setup_proc_list_sort_by ||
+        interface->setup_win.options_selected[0] == setup_proc_list_sort_by_secondary) {
       unsigned fields_count = process_field_displayed_count(interface->options.process_fields_displayed);
       if (!fields_count) {
         if (interface->setup_win.indentation_level > 1)
@@ -504,6 +512,10 @@ static void draw_setup_window_proc_list(struct nvtop_interface *interface) {
         if (interface->setup_win.options_selected[1] >= fields_count)
           interface->setup_win.options_selected[1] = fields_count - 1;
       }
+    }
+    if (interface->setup_win.options_selected[0] == setup_proc_list_show_only) {
+      if (interface->setup_win.options_selected[1] >= process_type_filter_count)
+        interface->setup_win.options_selected[1] = process_type_filter_count - 1;
     }
     if (interface->setup_win.options_selected[0] == setup_proc_list_display) {
       if (interface->setup_win.options_selected[1] >= process_field_count)
@@ -592,6 +604,56 @@ static void draw_setup_window_proc_list(struct nvtop_interface *interface) {
         wcolor_set(value_list_win, magenta_color, NULL);
         mvwprintw(value_list_win, 1, 0, "Nothing to sort: none of the process fields are displayed");
         wstandend(value_list_win);
+      }
+    }
+    // Sort by (secondary)
+    if (interface->setup_win.options_selected[0] == setup_proc_list_sort_by_secondary) {
+      wattr_set(value_list_win, A_STANDOUT, green_color, NULL);
+      mvwprintw(value_list_win, 0, 0, "Then sort by:");
+      wstandend(value_list_win);
+      wclrtoeol(value_list_win);
+      getmaxyx(value_list_win, tmp, maxcols);
+      getyx(value_list_win, tmp, cur_col);
+      mvwchgat(value_list_win, 0, cur_col, maxcols - cur_col, A_STANDOUT, green_color, NULL);
+      unsigned index = 0;
+      for (enum process_field field = process_pid; field < process_field_count; ++field) {
+        if (process_is_field_displayed(field, interface->options.process_fields_displayed)) {
+          option_state = interface->options.sort_processes_by_secondary == field;
+          mvwprintw(value_list_win, index + 1, 0, "[%c] %s", option_state_char(option_state),
+                    setup_proc_list_value_descriptions[field]);
+          wclrtoeol(value_list_win);
+          if (interface->setup_win.indentation_level == 2 && interface->setup_win.options_selected[1] == index) {
+            mvwchgat(value_list_win, index + 1, 0, 3, A_STANDOUT, cyan_color, NULL);
+            wmove(value_list_win, field + 2, 0);
+          }
+          index++;
+        }
+      }
+      if (!index) {
+        wcolor_set(value_list_win, magenta_color, NULL);
+        mvwprintw(value_list_win, 1, 0, "Nothing to sort: none of the process fields are displayed");
+        wstandend(value_list_win);
+      }
+    }
+    // Show only process type
+    if (interface->setup_win.options_selected[0] == setup_proc_list_show_only) {
+      wattr_set(value_list_win, A_STANDOUT, green_color, NULL);
+      mvwprintw(value_list_win, 0, 0, "Display process types:");
+      wstandend(value_list_win);
+      wclrtoeol(value_list_win);
+      getmaxyx(value_list_win, tmp, maxcols);
+      getyx(value_list_win, tmp, cur_col);
+      mvwchgat(value_list_win, 0, cur_col, maxcols - cur_col, A_STANDOUT, green_color, NULL);
+      for (enum process_type_filter f = process_type_filter_all; f < process_type_filter_count; ++f) {
+        option_state = interface->options.process_type_filter == f;
+        mvwprintw(value_list_win, (int)f + 1, 0, "[%c] %s", option_state_char(option_state),
+                  setup_proc_list_filter_values[f]);
+        wclrtoeol(value_list_win);
+        if (interface->setup_win.indentation_level == 2 &&
+            interface->setup_win.options_selected[1] == (unsigned)f) {
+          mvwchgat(value_list_win, (int)f + 1, 0, 3, A_STANDOUT, cyan_color, NULL);
+          wmove(value_list_win, (int)f + 2, 0);
+        }
       }
     }
     // Process field displayed
@@ -887,7 +949,9 @@ void handle_setup_win_keypress(int keyId, struct nvtop_interface *interface) {
             interface->options.filter_nvtop_pid = !interface->options.filter_nvtop_pid;
           } else if (interface->setup_win.options_selected[0] == setup_proc_list_hide_process_list) {
             interface->options.hide_processes_list = !interface->options.hide_processes_list;
-          } else if (interface->setup_win.options_selected[0] == setup_proc_list_sort_by) {
+          } else if (interface->setup_win.options_selected[0] == setup_proc_list_sort_by ||
+                     interface->setup_win.options_selected[0] == setup_proc_list_sort_by_secondary ||
+                     interface->setup_win.options_selected[0] == setup_proc_list_show_only) {
             handle_setup_win_keypress(KEY_RIGHT, interface);
           }
         } else if (interface->setup_win.indentation_level == 2) {
@@ -900,6 +964,20 @@ void handle_setup_win_keypress(int keyId, struct nvtop_interface *interface) {
                 index++;
               }
             }
+          }
+          if (interface->setup_win.options_selected[0] == setup_proc_list_sort_by_secondary) {
+            unsigned index = 0;
+            for (enum process_field field = process_pid; field < process_field_count; ++field) {
+              if (process_is_field_displayed(field, interface->options.process_fields_displayed)) {
+                if (index == interface->setup_win.options_selected[1])
+                  interface->options.sort_processes_by_secondary = field;
+                index++;
+              }
+            }
+          }
+          if (interface->setup_win.options_selected[0] == setup_proc_list_show_only) {
+            interface->options.process_type_filter =
+                (enum process_type_filter)interface->setup_win.options_selected[1];
           }
           if (interface->setup_win.options_selected[0] == setup_proc_list_display) {
             if (process_is_field_displayed(interface->setup_win.options_selected[1],


### PR DESCRIPTION
Two related process-list enhancements.

## #294 — Filter the process list by workload type
New `Show only process type` option: **All / Compute only / Graphical only**. Useful when you mainly care about compute workloads and want to hide graphical processes.

- New `enum process_type_filter` option; filter applied after the per-device process lists are merged.
- Selectable in the **F2 → Process List** menu (new "Show only process type" dropdown) and persisted in the config (`ProcessTypeFilter = all|compute|graphical`).
- Semantics: *compute only* keeps compute + compute+graphical (+ unknown, so untyped entries aren't silently hidden); *graphical only* keeps graphical + compute+graphical.

**Validated on a DGX Spark (GB10)**: with the single running CUDA process (compute type), `all` and `compute` show it and `graphical` hides it.

## #473 — Secondary sort key (multi-field sort)
Sort by a primary field **then** a secondary field, e.g. *GPU% desc, then GPU memory desc*.

- New `sort_processes_by_secondary` option.
- The **F6 sort window** now shows `Sort by`/`Then by` and **Tab** switches between editing the primary and secondary key (the `*` marks the current key for the active mode).
- Also selectable under **F2 → Process List → "Sort by (then)"**.
- Persisted in the config (`SortBySecondary = ...`, e.g. `none` when unset).
- A uniform ascending/descending direction applies to all sort keys (matching the request's "GPU usage % Desc, then GPU Memory Desc").

## Implementation
- Refactored the per-field comparators into one three-way `compare_process_field()` plus a small chained multi-key comparator (`compare_process_multi`), since `qsort` needs consistent `0`/tie handling for stable multi-key ordering. This also fixes the pre-existing `compare_process_type_asc` copy-paste bug (it was comparing by name).
- Adds `process_none` sentinel and `enum process_type_filter`.

## Testing
- `#294` filter verified at runtime on real hardware (compute/all show the process, graphical hides it).
- `#473` ordering verified with a unit-style harness (GPU desc→mem desc yields expected order; tie-break works).
- Config save/load round-trip verified (`F12` writes `SortBySecondary`/`ProcessTypeFilter`; snapshot loads them cleanly).
- Clean build; F2 setup window and F6 sort window render without regressions.

Closes #294 and #473.