### PR TITLE
fix: give the shader core count a field it fits in

### DIFF
--- a/src/interface.c
+++ b/src/interface.c
@@ -44,7 +44,7 @@
 
 static unsigned int sizeof_device_field[device_field_count] = {
     [device_name] = 11,       [device_fan_speed] = 11,   [device_temperature] = 10, [device_power] = 15,
-    [device_clock] = 11,      [device_mem_clock] = 12,   [device_pcie] = 46,        [device_shadercores] = 7,
+    [device_clock] = 11,      [device_mem_clock] = 12,   [device_pcie] = 46,        [device_shadercores] = 11,
     [device_l2features] = 11, [device_execengines] = 11,
 };
 


### PR DESCRIPTION
The GPU info bar reserves 7 columns for the shader core count, and the `NSHC ` label already takes 5 of them. The value gets 2 columns, so even the placeholder does not fit:

```
 NSHC N/ L2CF N/A    NEXC N/A
```

With 11 columns, the same width the two fields beside it use, it reads as intended and the three fields line up:

```
 NSHC N/A    L2CF N/A    NEXC N/A
```

11 also leaves room for the counts the panfrost (`util_last_bit(shader)`) and radeon (active CU count) backends actually report, which were being cut down as well.

The row is 35 columns wide after the change and the device box is at least 64, so nothing else moves.

While looking at this I noticed `L2CF` can overflow its field too: panfrost sets `l2cache_size` to `l2_cache_features & (0xFF << 16)`, which can reach 8 digits against 6 columns of room. That looked like it might be a separate question about the value rather than the field, so I left it alone.