### PR TITLE
feat: show the clock domains NVML does not report (XBAR, SYS, NVD)

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -118,6 +118,12 @@ Kepler microarchitecture. Anything starting at GeForce 600, GeForce 800M and
 successor should work fine. For more information about supported GPUs please
 take a look at the [NVML documentation](http://docs.nvidia.com/deploy/nvml-api/nvml-api-reference.html#nvml-api-reference).
 
+The extra clock domains bar (`nvtop -x`) shows the XBAR, SYS and NVD clocks,
+which NVML does not report, and `nvtop -X` adds the secondary HUB, HOST, DISP,
+MSD and UTILS ones. They are read through the *NvAPI library*
+(`libnvidia-api.so.1`) that recent drivers install alongside NVML; without it
+the rest of the interface is unaffected and the bar takes no room on screen.
+
 ### Adreno
 
 NVTOP supports Adreno GPUs using the `msm` linux driver.
@@ -190,6 +196,8 @@ Several libraries are required in order for NVTOP to display GPU info:
   * This makes the screen look beautiful.
 * For NVIDIA: the *NVIDIA Management Library* (*NVML*) which comes with the GPU driver.
   * This queries the GPU for info.
+  * The *NvAPI library* (`libnvidia-api.so.1`), also from the driver, is used
+    when present for the clock domains NVML does not report. It is optional.
 * For AMD: the libdrm library used to query AMD GPUs through the kernel driver.
 * For METAX: the *MetaX System Management Library* (*MXSML*) which comes with the GPU driver.
   * This queries the GPU for info.

--- a/include/nvtop/extract_gpuinfo_common.h
+++ b/include/nvtop/extract_gpuinfo_common.h
@@ -107,7 +107,19 @@ enum gpuinfo_dynamic_info_valid {
   gpuinfo_power_draw_max_valid,
   gpuinfo_effective_load_rate_valid,
   gpuinfo_multi_instance_mode_valid,
+  gpuinfo_extra_clocks_valid,
   gpuinfo_dynamic_info_count,
+};
+
+// Clock domains a driver exposes on top of the graphics and memory ones, which
+// have no vendor neutral meaning and are therefore carried with their name.
+#define MAX_EXTRA_CLOCK_DOMAINS 8
+#define EXTRA_CLOCK_NAME_LEN 8
+
+struct gpuinfo_extra_clock {
+  char name[EXTRA_CLOCK_NAME_LEN]; // Domain name as the vendor calls it
+  unsigned int speed;              // Domain clock speed in MHz
+  bool secondary;                  // True for the domains only shown on request
 };
 
 struct gpuinfo_dynamic_info {
@@ -133,6 +145,8 @@ struct gpuinfo_dynamic_info {
   unsigned int power_draw;          // Power usage in milliwatts
   unsigned int power_draw_max;      // Max power usage in milliwatts
   bool multi_instance_mode;          // True if the GPU is in multi-instance mode
+  unsigned int extra_clock_count;   // Number of populated entries in extra_clocks
+  struct gpuinfo_extra_clock extra_clocks[MAX_EXTRA_CLOCK_DOMAINS];
   unsigned char valid[(gpuinfo_dynamic_info_count + CHAR_BIT - 1) / CHAR_BIT];
 };
 
@@ -227,6 +241,13 @@ void register_gpu_vendor(struct gpu_vendor *vendor);
 bool extract_drm_fdinfo_key_value(char *buf, char **key, char **val);
 
 void gpuinfo_refresh_utilisation_rate(struct gpu_info *gpu_info);
+
+// Appends a vendor specific clock domain to the dynamic info, ignoring the call
+// once MAX_EXTRA_CLOCK_DOMAINS of them have been reported. A secondary domain is
+// one the user has to ask for, for domains that say little about how the GPU is
+// performing.
+void gpuinfo_add_extra_clock(struct gpuinfo_dynamic_info *dynamic_info, const char *name, unsigned int speed_mhz,
+                             bool secondary);
 
 // fdinfo DRM interface names common to multiple drivers
 extern const char drm_pdev[];

--- a/include/nvtop/interface_internal_common.h
+++ b/include/nvtop/interface_internal_common.h
@@ -23,6 +23,7 @@
 #define INTERFACE_INTERNAL_COMMON_H__
 
 #include "nvtop/common.h"
+#include "nvtop/extract_gpuinfo_common.h"
 #include "nvtop/interface_options.h"
 #include "nvtop/interface_ring_buffer.h"
 #include "nvtop/time.h"
@@ -73,6 +74,7 @@ struct device_window {
   WINDOW *shader_cores;
   WINDOW *l2_cache_size;
   WINDOW *exec_engines;
+  WINDOW *extra_clocks[MAX_EXTRA_CLOCK_DOMAINS];
   bool enc_was_visible;
   bool dec_was_visible;
   nvtop_time last_decode_seen;
@@ -138,6 +140,7 @@ struct nvtop_interface {
   struct process_window process;
   WINDOW *shortcut_window;
   unsigned num_plots;
+  unsigned extra_clock_rows; // Rows the current layout reserves for the clock domains
   struct plot_window *plots;
   interface_ring_buffer saved_data_ring;
   struct setup_window setup_win;
@@ -154,6 +157,7 @@ enum device_field {
   device_shadercores,
   device_l2features,
   device_execengines,
+  device_extra_clock,
   device_field_count,
 };
 

--- a/include/nvtop/interface_options.h
+++ b/include/nvtop/interface_options.h
@@ -51,6 +51,8 @@ typedef struct nvtop_interface_option_struct {
   bool filter_nvtop_pid;                            // Do not show nvtop pid in the processes list
   bool has_monitored_set_changed;                   // True if the set of monitored gpu was modified through the interface
   bool has_gpu_info_bar;                            // Show info bar with additional GPU parameters
+  bool has_extra_clocks_bar;                        // Show bar with the clock domains besides graphics and memory
+  bool has_all_clocks_bar;                          // Extend that bar with the secondary clock domains
   bool hide_processes_list;                         // Hide processes list
   unsigned char gpu_plot_color_idx[MAX_LINES_PER_PLOT]; // index into plot_color_names[] per plot slot
 } nvtop_interface_option;

--- a/manpage/nvtop.in
+++ b/manpage/nvtop.in
@@ -8,7 +8,7 @@ nvtop \- interactive GPU process viewer
 
 .SH SYNOPSIS
 .B nvtop
-\fR[\fB\-hvCfpPris\fR]
+\fR[\fB\-hvCfpPrisxX\fR]
 \fR[\fB\-d\fR \fIdelay\fR]
 \fR[\fB\-c\fR \fIconfig-file\fR]
 \fR[\fB\-E\fR \fIseconds\fR]
@@ -39,6 +39,12 @@ Reverse abscissa: switch the plot data order from "old --- recent" (default) to 
 .BR \-p ", " \-\-no\-plot
 Show only one bar plot corresponding to the maximum of all GPUs.
 .TP
+.BR \-x ", " \-\-extra\-clocks
+Show a bar with the clock domains a GPU exposes besides the graphics and memory ones. On NVIDIA these are XBAR, SYS and NVD, and reading them needs the NvAPI library the driver installs. The bar takes no room on a GPU that reports no such domain.
+.TP
+.BR \-X ", " \-\-all\-clocks
+Extend that bar with the secondary clock domains, the ones that sit at a fixed frequency most of the time. On NVIDIA these are HUB, HOST, DISP, MSD and UTILS.
+.TP
 .BR \-v ", " \-\-version
 Print the version and exit.
 
@@ -50,7 +56,7 @@ You can enter the setup utility by pressing \fBF2\fR to view and modify the foll
 This section deals with general interface options. \fBColor support\fR and \fBinterface update interval\fR can be modified.
 .TP
 .I Devices
-This section deals with the devices display (top of the interface). You can \fBswitch the temperature scale to fahrenheit\fR and \fBset the encoder/decoder hiding timer\fR.
+This section deals with the devices display (top of the interface). You can \fBswitch the temperature scale to fahrenheit\fR, \fBset the encoder/decoder hiding timer\fR, \fBdisplay the extra GPU info bar\fR, \fBdisplay the extra clock domains\fR and \fBinclude the secondary ones among them\fR.
 .TP
 .I Chart
 This section deals with the line plots (middle of the interface). You can \fBreverse the plot direction\fR and \fBselect which metric is being shown in the plots\fR.

--- a/src/extract_gpuinfo.c
+++ b/src/extract_gpuinfo.c
@@ -21,6 +21,7 @@
 
 #include <ctype.h>
 #include <math.h>
+#include <stdio.h>
 #include <stdlib.h>
 
 #include "nvtop/extract_gpuinfo.h"
@@ -404,4 +405,23 @@ void gpuinfo_refresh_utilisation_rate(struct gpu_info *gpu_info) {
   utilisation_rate = utilisation_rate > 100 ? 100 : utilisation_rate;
 
   SET_GPUINFO_DYNAMIC(&gpu_info->dynamic_info, gpu_util_rate, utilisation_rate);
+}
+
+void gpuinfo_add_extra_clock(struct gpuinfo_dynamic_info *dynamic_info, const char *name, unsigned int speed_mhz,
+                             bool secondary) {
+  // The count lives as long as the valid bit does, so the RESET_ALL every
+  // vendor does at the start of a refresh empties the array as well.
+  if (!IS_VALID(gpuinfo_extra_clocks_valid, dynamic_info->valid))
+    dynamic_info->extra_clock_count = 0;
+
+  if (dynamic_info->extra_clock_count >= MAX_EXTRA_CLOCK_DOMAINS)
+    return;
+
+  struct gpuinfo_extra_clock *clock = &dynamic_info->extra_clocks[dynamic_info->extra_clock_count];
+  snprintf(clock->name, sizeof(clock->name), "%s", name);
+  clock->speed = speed_mhz;
+  clock->secondary = secondary;
+
+  dynamic_info->extra_clock_count++;
+  SET_VALID(gpuinfo_extra_clocks_valid, dynamic_info->valid);
 }

--- a/src/extract_gpuinfo_nvidia.c
+++ b/src/extract_gpuinfo_nvidia.c
@@ -207,6 +207,165 @@ static nvmlReturn_t (*nvmlDeviceGetMPSComputeRunningProcesses[4])(nvmlDevice_t d
 #define NVML_DEVICE_MIG_ENABLE 0x1
 nvmlReturn_t (*nvmlDeviceGetMigMode)(nvmlDevice_t device, unsigned int *currentMode, unsigned int *pendingMode);
 
+// NvAPI is a second, undocumented entry point into the driver. It is used here
+// for one thing only: the clock domains that NVML does not report, such as the
+// XBAR clock the memory subsystem runs at. Everything is resolved through
+// nvapi_QueryInterface, so a driver without the library, or without these
+// particular entry points, simply reports no extra clocks.
+
+#define NVAPI_OK 0
+#define NVAPI_MAX_PHYSICAL_GPUS 64
+#define NVAPI_MAX_CLOCK_DOMAINS 32
+
+#define NVAPI_QUERY_INITIALIZE 0x0150e828u
+#define NVAPI_QUERY_UNLOAD 0xd22bdd7eu
+#define NVAPI_QUERY_ENUM_PHYSICAL_GPUS 0xe5ac921fu
+#define NVAPI_QUERY_GPU_GET_BUS_ID 0x1be0b8e5u
+#define NVAPI_QUERY_GPU_GET_ALL_CLOCKS 0x1bd69f49u
+
+typedef void *NvPhysicalGpuHandle;
+typedef int NvAPI_Status;
+
+typedef struct {
+  unsigned int frequency; // In kHz
+  unsigned int bitfield;  // Bit 0 tells whether the domain is present
+} nvapiClockDomain_t;
+
+typedef struct {
+  unsigned int effective_frequency;
+  unsigned int ratio_domain;
+  unsigned int ratio;
+  unsigned int reserved[4];
+} nvapiClockDomainExtended_t;
+
+typedef struct {
+  unsigned int version; // Structure size in the low half, version in the high one
+  nvapiClockDomain_t domain[NVAPI_MAX_CLOCK_DOMAINS];
+  nvapiClockDomainExtended_t extended[NVAPI_MAX_CLOCK_DOMAINS];
+} nvapiAllClocks_t;
+
+// The clock domains reported next to the graphics and memory ones. Domain 0 is
+// the graphics clock and domain 4 the memory clock, both of which NVML already
+// reports, so they are deliberately left out. So is domain 31, which carries the
+// PCIe link generation rather than a frequency.
+//
+// The first three are the ones that move with a workload and explain what the
+// GPU is doing under a power limit; the rest are secondary, sitting at a fixed
+// frequency most of the time.
+//
+// Domain 20 is named NVD after measurement rather than after any header: giving
+// it a frequency offset raises NVENC throughput by the same proportion, which a
+// power management clock would not do.
+static const struct {
+  unsigned int id;
+  const char *name;
+  bool secondary;
+} nvapi_extra_clock_domains[] = {
+    {1, "XBAR", false},  {2, "SYS", false},  {20, "NVD", false}, {3, "HUB", true},
+    {5, "HOST", true},   {6, "DISP", true},  {21, "MSD", true},  {22, "UTILS", true},
+};
+
+static void *libnvidia_api_handle;
+
+static void *(*nvapi_QueryInterface)(unsigned int id);
+static NvAPI_Status (*nvapi_Initialize)(void);
+static NvAPI_Status (*nvapi_Unload)(void);
+static NvAPI_Status (*nvapi_EnumPhysicalGPUs)(NvPhysicalGpuHandle handles[NVAPI_MAX_PHYSICAL_GPUS],
+                                              unsigned int *count);
+static NvAPI_Status (*nvapi_GPU_GetBusId)(NvPhysicalGpuHandle handle, unsigned int *busId);
+static NvAPI_Status (*nvapi_GPU_GetAllClocks)(NvPhysicalGpuHandle handle, nvapiAllClocks_t *clocks);
+
+static NvPhysicalGpuHandle nvapi_handles[NVAPI_MAX_PHYSICAL_GPUS];
+static unsigned int nvapi_bus_ids[NVAPI_MAX_PHYSICAL_GPUS];
+static unsigned int nvapi_handle_count;
+static bool nvapi_initialized;
+
+static void gpuinfo_nvidia_nvapi_shutdown(void) {
+  if (!libnvidia_api_handle)
+    return;
+  if (nvapi_initialized && nvapi_Unload)
+    nvapi_Unload();
+  dlclose(libnvidia_api_handle);
+  libnvidia_api_handle = NULL;
+  nvapi_initialized = false;
+  nvapi_handle_count = 0;
+}
+
+// Optional: a failure here only costs the extra clock domains, so it never
+// fails the NVIDIA extraction as a whole.
+static void gpuinfo_nvidia_nvapi_init(void) {
+  libnvidia_api_handle = dlopen("libnvidia-api.so.1", RTLD_LAZY);
+  if (!libnvidia_api_handle)
+    return;
+
+  nvapi_QueryInterface = dlsym(libnvidia_api_handle, "nvapi_QueryInterface");
+  if (!nvapi_QueryInterface)
+    goto clean_exit;
+
+  nvapi_Initialize = nvapi_QueryInterface(NVAPI_QUERY_INITIALIZE);
+  nvapi_Unload = nvapi_QueryInterface(NVAPI_QUERY_UNLOAD);
+  nvapi_EnumPhysicalGPUs = nvapi_QueryInterface(NVAPI_QUERY_ENUM_PHYSICAL_GPUS);
+  nvapi_GPU_GetBusId = nvapi_QueryInterface(NVAPI_QUERY_GPU_GET_BUS_ID);
+  nvapi_GPU_GetAllClocks = nvapi_QueryInterface(NVAPI_QUERY_GPU_GET_ALL_CLOCKS);
+  if (!nvapi_Initialize || !nvapi_EnumPhysicalGPUs || !nvapi_GPU_GetBusId || !nvapi_GPU_GetAllClocks)
+    goto clean_exit;
+
+  if (nvapi_Initialize() != NVAPI_OK)
+    goto clean_exit;
+  nvapi_initialized = true;
+
+  unsigned int count = 0;
+  if (nvapi_EnumPhysicalGPUs(nvapi_handles, &count) != NVAPI_OK)
+    goto clean_exit;
+
+  for (unsigned int i = 0; i < count && i < NVAPI_MAX_PHYSICAL_GPUS; ++i) {
+    if (nvapi_GPU_GetBusId(nvapi_handles[i], &nvapi_bus_ids[nvapi_handle_count]) != NVAPI_OK)
+      continue;
+    nvapi_handles[nvapi_handle_count] = nvapi_handles[i];
+    nvapi_handle_count++;
+  }
+  return;
+
+clean_exit:
+  gpuinfo_nvidia_nvapi_shutdown();
+}
+
+// NvAPI identifies a GPU by its PCI bus number alone, so a machine with several
+// PCI domains could in principle have two GPUs answer to the same number. Such
+// a pair is left unmatched instead of guessing.
+static NvPhysicalGpuHandle gpuinfo_nvidia_nvapi_handle(unsigned int bus) {
+  NvPhysicalGpuHandle found = NULL;
+
+  for (unsigned int i = 0; i < nvapi_handle_count; ++i) {
+    if (nvapi_bus_ids[i] != bus)
+      continue;
+    if (found)
+      return NULL;
+    found = nvapi_handles[i];
+  }
+  return found;
+}
+
+static void gpuinfo_nvidia_refresh_extra_clocks(NvPhysicalGpuHandle handle,
+                                                struct gpuinfo_dynamic_info *dynamic_info) {
+  if (!handle)
+    return;
+
+  nvapiAllClocks_t clocks;
+  memset(&clocks, 0, sizeof(clocks));
+  clocks.version = (unsigned int)(sizeof(clocks) | (2u << 16));
+  if (nvapi_GPU_GetAllClocks(handle, &clocks) != NVAPI_OK)
+    return;
+
+  for (size_t i = 0; i < sizeof(nvapi_extra_clock_domains) / sizeof(*nvapi_extra_clock_domains); ++i) {
+    const nvapiClockDomain_t *domain = &clocks.domain[nvapi_extra_clock_domains[i].id];
+    if (!(domain->bitfield & 1) || !domain->frequency)
+      continue;
+    gpuinfo_add_extra_clock(dynamic_info, nvapi_extra_clock_domains[i].name, domain->frequency / 1000,
+                            nvapi_extra_clock_domains[i].secondary);
+  }
+}
+
 static void *libnvidia_ml_handle;
 
 static nvmlReturn_t last_nvml_return_status = NVML_SUCCESS;
@@ -274,6 +433,7 @@ struct gpu_info_nvidia {
   struct list_head allocate_list;
 
   nvmlDevice_t gpuhandle;
+  NvPhysicalGpuHandle nvapihandle; // NULL unless NvAPI resolved this same GPU
   bool isInMigMode;
   unsigned long long last_utilization_timestamp;
 };
@@ -476,6 +636,8 @@ static bool gpuinfo_nvidia_init(void) {
   }
   local_error_string = NULL;
 
+  gpuinfo_nvidia_nvapi_init();
+
   return true;
 
 init_error_clean_exit:
@@ -485,6 +647,8 @@ init_error_clean_exit:
 }
 
 static void gpuinfo_nvidia_shutdown(void) {
+  gpuinfo_nvidia_nvapi_shutdown();
+
   if (libnvidia_ml_handle) {
     nvmlShutdown();
     dlclose(libnvidia_ml_handle);
@@ -538,6 +702,7 @@ static bool gpuinfo_nvidia_get_device_handles(struct list_head *devices, unsigne
       nvmlReturn_t pciInfoRet = nvmlDeviceGetPciInfo(gpu_infos[*count].gpuhandle, &pciInfo);
       if (pciInfoRet == NVML_SUCCESS) {
         strncpy(gpu_infos[*count].base.pdev, pciInfo.busIdLegacy, PDEV_LEN);
+        gpu_infos[*count].nvapihandle = gpuinfo_nvidia_nvapi_handle(pciInfo.bus);
         list_add_tail(&gpu_infos[*count].base.list, devices);
         *count += 1;
       }
@@ -627,6 +792,9 @@ static void gpuinfo_nvidia_refresh_dynamic_info(struct gpu_info *_gpu_info) {
   last_nvml_return_status = nvmlDeviceGetMaxClockInfo(device, NVML_CLOCK_MEM, &dynamic_info->mem_clock_speed_max);
   if (last_nvml_return_status == NVML_SUCCESS)
     SET_VALID(gpuinfo_mem_clock_speed_max_valid, dynamic_info->valid);
+
+  // Clock domains NVML does not report, such as XBAR
+  gpuinfo_nvidia_refresh_extra_clocks(gpu_info->nvapihandle, dynamic_info);
 
   // CPU and Memory utilization rates
   nvmlUtilization_t utilization_percentages;

--- a/src/interface.c
+++ b/src/interface.c
@@ -42,10 +42,13 @@
 #include <tgmath.h>
 #include <unistd.h>
 
+// A device box is device_length() columns wide, which fits this many clock fields
+#define EXTRA_CLOCKS_PER_ROW 4
+
 static unsigned int sizeof_device_field[device_field_count] = {
     [device_name] = 11,       [device_fan_speed] = 11,   [device_temperature] = 10, [device_power] = 15,
     [device_clock] = 11,      [device_mem_clock] = 12,   [device_pcie] = 46,        [device_shadercores] = 7,
-    [device_l2features] = 11, [device_execengines] = 11,
+    [device_l2features] = 11, [device_execengines] = 11, [device_extra_clock] = 15,
 };
 
 static unsigned int sizeof_process_field[process_field_count] = {
@@ -56,9 +59,14 @@ static unsigned int sizeof_process_field[process_field_count] = {
 };
 
 static void alloc_device_window(unsigned int start_row, unsigned int start_col, unsigned int totalcol,
+                                const nvtop_interface_option *options, unsigned int extra_clock_rows,
                                 struct device_window *dwin) {
 
   const unsigned int spacer = 1;
+
+  // Not every clock domain slot gets a window, so the unused ones have to read
+  // as absent rather than as leftovers of the previous layout
+  memset(dwin->extra_clocks, 0, sizeof(dwin->extra_clocks));
 
   // Line 1 = Name | PCIe info
 
@@ -178,6 +186,19 @@ static void alloc_device_window(unsigned int start_row, unsigned int start_col, 
   if (dwin->exec_engines == NULL)
     goto alloc_error;
 
+  // Clock domains besides the graphics and memory ones, on the rows following
+  // the GPU info bar when that one is displayed. Only the domains the reserved
+  // rows have room for get a window; the rest stay NULL.
+  unsigned int extra_clocks_row = start_row + 3 + (options->has_gpu_info_bar ? 1 : 0);
+  unsigned int extra_clocks_shown = min(extra_clock_rows * EXTRA_CLOCKS_PER_ROW, MAX_EXTRA_CLOCK_DOMAINS);
+  for (unsigned int i = 0; i < extra_clocks_shown; ++i) {
+    dwin->extra_clocks[i] =
+        newwin(1, sizeof_device_field[device_extra_clock], extra_clocks_row + i / EXTRA_CLOCKS_PER_ROW,
+               start_col + (i % EXTRA_CLOCKS_PER_ROW) * (sizeof_device_field[device_extra_clock] + spacer));
+    if (dwin->extra_clocks[i] == NULL)
+      goto alloc_error;
+  }
+
   return;
 alloc_error:
   endwin();
@@ -205,6 +226,10 @@ static void free_device_windows(struct device_window *dwin) {
   delwin(dwin->shader_cores);
   delwin(dwin->l2_cache_size);
   delwin(dwin->exec_engines);
+  for (unsigned int i = 0; i < MAX_EXTRA_CLOCK_DOMAINS; ++i) {
+    if (dwin->extra_clocks[i])
+      delwin(dwin->extra_clocks[i]);
+  }
 }
 
 static void alloc_process_with_option(struct nvtop_interface *interface, unsigned posX, unsigned posY, unsigned sizeX,
@@ -367,7 +392,8 @@ static void initialize_all_windows(struct nvtop_interface *dwin) {
   struct window_position plot_positions[MAX_CHARTS];
   struct window_position setup_position;
 
-  compute_sizes_from_layout(devices_count, dwin->options.has_gpu_info_bar ? 4 : 3, device_length(), rows - 1, cols,
+  unsigned int device_rows = 3 + (dwin->options.has_gpu_info_bar ? 1 : 0) + dwin->extra_clock_rows;
+  compute_sizes_from_layout(devices_count, device_rows, device_length(), rows - 1, cols,
                             dwin->options.gpu_specific_opts, dwin->options.process_fields_displayed, device_positions,
                             &dwin->num_plots, plot_positions, map_device_to_plot, &process_position, &setup_position,
                             dwin->options.hide_processes_list);
@@ -375,8 +401,8 @@ static void initialize_all_windows(struct nvtop_interface *dwin) {
   alloc_plot_window(devices_count, plot_positions, map_device_to_plot, dwin);
 
   for (unsigned int i = 0; i < devices_count; ++i) {
-    alloc_device_window(device_positions[i].posY, device_positions[i].posX, device_positions[i].sizeX,
-                        &dwin->devices_win[i]);
+    alloc_device_window(device_positions[i].posY, device_positions[i].posX, device_positions[i].sizeX, &dwin->options,
+                        dwin->extra_clock_rows, &dwin->devices_win[i]);
   }
 
   alloc_process_with_option(dwin, process_position.posX, process_position.posY, process_position.sizeX,
@@ -657,6 +683,60 @@ static void encode_decode_show_select(struct device_window *dev, bool encode_val
   }
 }
 
+static bool extra_clock_is_shown(const struct gpuinfo_extra_clock *clock, const nvtop_interface_option *options) {
+  if (clock->secondary)
+    return options->has_all_clocks_bar;
+  return options->has_extra_clocks_bar || options->has_all_clocks_bar;
+}
+
+static unsigned extra_clocks_visible(const struct gpuinfo_dynamic_info *dynamic_info,
+                                     const nvtop_interface_option *options) {
+  if (!IS_VALID(gpuinfo_extra_clocks_valid, dynamic_info->valid))
+    return 0;
+
+  unsigned count = 0;
+  for (unsigned i = 0; i < dynamic_info->extra_clock_count; ++i) {
+    if (extra_clock_is_shown(&dynamic_info->extra_clocks[i], options))
+      count++;
+  }
+  return count;
+}
+
+// How many clock domains a device reports is only known once it has been
+// refreshed at least once, which happens after the windows are first laid out,
+// so the reserved rows are revisited on every draw. A device that reports none
+// costs no row at all, which is the usual case outside NVIDIA.
+static void update_extra_clock_rows(struct list_head *devices, struct nvtop_interface *interface) {
+  unsigned rows_needed = 0;
+
+  if (interface->options.has_extra_clocks_bar || interface->options.has_all_clocks_bar) {
+    struct gpu_info *device;
+    unsigned most_clocks = 0;
+    list_for_each_entry(device, devices, list) {
+      unsigned visible = extra_clocks_visible(&device->dynamic_info, &interface->options);
+      most_clocks = max(most_clocks, visible);
+    }
+    rows_needed = (most_clocks + EXTRA_CLOCKS_PER_ROW - 1) / EXTRA_CLOCKS_PER_ROW;
+    // A driver that fails one read should not make the whole interface jump, so
+    // rows are only ever given back when the options change
+    rows_needed = max(rows_needed, interface->extra_clock_rows);
+  }
+
+  if (rows_needed == interface->extra_clock_rows)
+    return;
+
+  // Laying the windows out again closes the setup window, so a change made from
+  // there only takes effect once the user is done with it
+  if (interface->setup_win.visible)
+    return;
+
+  interface->extra_clock_rows = rows_needed;
+  erase();
+  refresh();
+  delete_all_windows(interface);
+  initialize_all_windows(interface);
+}
+
 static void draw_devices(struct list_head *devices, struct nvtop_interface *interface) {
   struct gpu_info *device;
   unsigned dev_id = 0;
@@ -901,6 +981,29 @@ static void draw_devices(struct list_head *devices, struct nvtop_interface *inte
         wprintw(dev->exec_engines, "N/A");
 
       wnoutrefresh(dev->exec_engines);
+    }
+
+    // EXTRA CLOCK DOMAINS
+    // Every slot the layout did not reserve is a NULL window, so nothing is
+    // drawn at all while both options are off
+    unsigned extra_clock_slot = 0;
+    if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, extra_clocks)) {
+      for (unsigned i = 0; i < device->dynamic_info.extra_clock_count; ++i) {
+        const struct gpuinfo_extra_clock *clock = &device->dynamic_info.extra_clocks[i];
+        if (!extra_clock_is_shown(clock, &interface->options))
+          continue;
+        if (extra_clock_slot >= MAX_EXTRA_CLOCK_DOMAINS || !dev->extra_clocks[extra_clock_slot])
+          break;
+        werase(dev->extra_clocks[extra_clock_slot]);
+        mvwprintw(dev->extra_clocks[extra_clock_slot], 0, 0, "%s %uMHz", clock->name, clock->speed);
+        mvwchgat(dev->extra_clocks[extra_clock_slot], 0, 0, (int)strlen(clock->name), 0, cyan_color, NULL);
+        wnoutrefresh(dev->extra_clocks[extra_clock_slot]);
+        extra_clock_slot++;
+      }
+    }
+    for (; extra_clock_slot < MAX_EXTRA_CLOCK_DOMAINS && dev->extra_clocks[extra_clock_slot]; ++extra_clock_slot) {
+      werase(dev->extra_clocks[extra_clock_slot]);
+      wnoutrefresh(dev->extra_clocks[extra_clock_slot]);
     }
 
     dev_id++;
@@ -1848,6 +1951,7 @@ static void draw_plots(struct nvtop_interface *interface) {
 
 void draw_gpu_info_ncurses(unsigned devices_count, struct list_head *devices, struct nvtop_interface *interface) {
 
+  update_extra_clock_rows(devices, interface);
   draw_devices(devices, interface);
   if (!interface->setup_win.visible) {
     draw_plots(interface);
@@ -2183,6 +2287,14 @@ void print_snapshot(struct list_head *devices, bool use_fahrenheit_option, bool 
       printf("%s\"%s\": \"%uMHz\",\n", indent_level_four, mem_clock_field, device->dynamic_info.mem_clock_speed);
     else
       printf("%s\"%s\": null,\n", indent_level_four, mem_clock_field);
+
+    // Vendor specific clock domains, keyed by the name the vendor gives them
+    unsigned extra_clock_count =
+        GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, extra_clocks) ? device->dynamic_info.extra_clock_count : 0;
+    for (unsigned i = 0; i < extra_clock_count; ++i) {
+      const struct gpuinfo_extra_clock *clock = &device->dynamic_info.extra_clocks[i];
+      printf("%s\"%s_clock\": \"%uMHz\",\n", indent_level_four, clock->name, clock->speed);
+    }
 
     // GPU Temperature
     if (GPUINFO_DYNAMIC_FIELD_VALID(&device->dynamic_info, gpu_temp)) {

--- a/src/interface_options.c
+++ b/src/interface_options.c
@@ -129,6 +129,8 @@ void alloc_interface_options_internals(char *config_location, unsigned num_devic
   options->show_startup_messages = true;
   options->filter_nvtop_pid = true;
   options->has_gpu_info_bar = false;
+  options->has_extra_clocks_bar = false;
+  options->has_all_clocks_bar = false;
   options->gpu_plot_color_idx[0] = 1;  // Cyan
   options->gpu_plot_color_idx[1] = 3;  // Yellow
   options->gpu_plot_color_idx[2] = 2;  // Green
@@ -175,6 +177,8 @@ static const char header_section[] = "HeaderOption";
 static const char header_value_use_fahrenheit[] = "UseFahrenheit";
 static const char header_value_encode_decode_timer[] = "EncodeHideTimer";
 static const char header_value_gpu_info_bar[] = "GPUInfoBar";
+static const char header_value_extra_clocks_bar[] = "ExtraClocksBar";
+static const char header_value_all_clocks_bar[] = "AllClocksBar";
 
 static const char chart_section[] = "ChartOption";
 static const char chart_value_reverse[] = "ReverseChart";
@@ -251,6 +255,22 @@ static int nvtop_option_ini_handler(void *user, const char *section, const char 
       }
       if (strcmp(value, "false") == 0) {
         ini_data->options->has_gpu_info_bar = false;
+      }
+    }
+    if (strcmp(name, header_value_extra_clocks_bar) == 0) {
+      if (strcmp(value, "true") == 0) {
+        ini_data->options->has_extra_clocks_bar = true;
+      }
+      if (strcmp(value, "false") == 0) {
+        ini_data->options->has_extra_clocks_bar = false;
+      }
+    }
+    if (strcmp(name, header_value_all_clocks_bar) == 0) {
+      if (strcmp(value, "true") == 0) {
+        ini_data->options->has_all_clocks_bar = true;
+      }
+      if (strcmp(value, "false") == 0) {
+        ini_data->options->has_all_clocks_bar = false;
       }
     }
   }
@@ -418,6 +438,8 @@ bool save_interface_options_to_config_file(unsigned total_dev_count, const nvtop
   fprintf(config_file, "%s = %s\n", header_value_use_fahrenheit, boolean_string(options->temperature_in_fahrenheit));
   fprintf(config_file, "%s = %e\n", header_value_encode_decode_timer, options->encode_decode_hiding_timer);
   fprintf(config_file, "%s = %s\n", header_value_gpu_info_bar, boolean_string(options->has_gpu_info_bar));
+  fprintf(config_file, "%s = %s\n", header_value_extra_clocks_bar, boolean_string(options->has_extra_clocks_bar));
+  fprintf(config_file, "%s = %s\n", header_value_all_clocks_bar, boolean_string(options->has_all_clocks_bar));
 
   // Chart Options
   fprintf(config_file, "\n[%s]\n", chart_section);

--- a/src/interface_setup_win.c
+++ b/src/interface_setup_win.c
@@ -58,12 +58,15 @@ enum setup_header_options {
   setup_header_toggle_fahrenheit,
   setup_header_enc_dec_timer,
   setup_header_gpu_info_bar,
+  setup_header_extra_clocks_bar,
+  setup_header_all_clocks_bar,
   setup_header_options_count
 };
 
 static const char *setup_header_option_descriptions[setup_header_options_count] = {
     "Temperature in fahrenheit", "Keep displaying Encoder/Decoder rate (after reaching an idle state)",
-    "Display extra GPU info bar"};
+    "Display extra GPU info bar", "Display the clock domains besides graphics and memory",
+    "Include the secondary clock domains in that bar"};
 
 // Chart Options
 
@@ -314,6 +317,24 @@ static void draw_setup_window_header(struct nvtop_interface *interface) {
   if (interface->setup_win.indentation_level == 1 &&
       interface->setup_win.options_selected[0] == setup_header_gpu_info_bar) {
     mvwchgat(options_win, setup_header_gpu_info_bar + 1, 0, 3, A_STANDOUT, cyan_color, NULL);
+  }
+
+  // Extra clock domains bar
+  option_state = interface->options.has_extra_clocks_bar;
+  mvwprintw(options_win, setup_header_extra_clocks_bar + 1, 0, "[%c] %s", option_state_char(option_state),
+            setup_header_option_descriptions[setup_header_extra_clocks_bar]);
+  if (interface->setup_win.indentation_level == 1 &&
+      interface->setup_win.options_selected[0] == setup_header_extra_clocks_bar) {
+    mvwchgat(options_win, setup_header_extra_clocks_bar + 1, 0, 3, A_STANDOUT, cyan_color, NULL);
+  }
+
+  // Secondary clock domains
+  option_state = interface->options.has_all_clocks_bar;
+  mvwprintw(options_win, setup_header_all_clocks_bar + 1, 0, "[%c] %s", option_state_char(option_state),
+            setup_header_option_descriptions[setup_header_all_clocks_bar]);
+  if (interface->setup_win.indentation_level == 1 &&
+      interface->setup_win.options_selected[0] == setup_header_all_clocks_bar) {
+    mvwchgat(options_win, setup_header_all_clocks_bar + 1, 0, 3, A_STANDOUT, cyan_color, NULL);
   }
   wnoutrefresh(options_win);
 }
@@ -817,6 +838,12 @@ void handle_setup_win_keypress(int keyId, struct nvtop_interface *interface) {
           }
           if (interface->setup_win.options_selected[0] == setup_header_gpu_info_bar) {
             interface->options.has_gpu_info_bar = !interface->options.has_gpu_info_bar;
+          }
+          if (interface->setup_win.options_selected[0] == setup_header_extra_clocks_bar) {
+            interface->options.has_extra_clocks_bar = !interface->options.has_extra_clocks_bar;
+          }
+          if (interface->setup_win.options_selected[0] == setup_header_all_clocks_bar) {
+            interface->options.has_all_clocks_bar = !interface->options.has_all_clocks_bar;
           }
         }
       }

--- a/src/nvtop.c
+++ b/src/nvtop.c
@@ -71,6 +71,9 @@ static const char helpstring[] = "Available options:\n"
                                  "line information\n"
                                  "  -f --freedom-unit : Use fahrenheit\n"
                                  "  -i --gpu-info     : Show bar with additional GPU parameters\n"
+                                 "  -x --extra-clocks : Show bar with the clock domains besides graphics "
+                                 "and memory\n"
+                                 "  -X --all-clocks   : Extend that bar with the secondary clock domains\n"
                                  "  -E --encode-hide  : Set encode/decode auto hide time in seconds "
                                  "(default 30s, negative = always on screen)\n"
                                  "  -h --help         : Print help and exit\n"
@@ -89,6 +92,8 @@ static const struct option long_opts[] = {
     {.name = "no-colour", .has_arg = no_argument, .flag = NULL, .val = 'C'},
     {.name = "freedom-unit", .has_arg = no_argument, .flag = NULL, .val = 'f'},
     {.name = "gpu-info", .has_arg = no_argument, .flag = NULL, .val = 'i'},
+    {.name = "extra-clocks", .has_arg = no_argument, .flag = NULL, .val = 'x'},
+    {.name = "all-clocks", .has_arg = no_argument, .flag = NULL, .val = 'X'},
     {.name = "encode-hide", .has_arg = required_argument, .flag = NULL, .val = 'E'},
     {.name = "no-plot", .has_arg = no_argument, .flag = NULL, .val = 'p'},
     {.name = "no-processes", .has_arg = no_argument, .flag = NULL, .val = 'P'},
@@ -98,7 +103,7 @@ static const struct option long_opts[] = {
     {0, 0, 0, 0},
 };
 
-static const char opts[] = "hvd:c:CfE:pPrisl";
+static const char opts[] = "hvd:c:CfE:pPrislxX";
 
 int main(int argc, char **argv) {
   (void)setlocale(LC_CTYPE, "");
@@ -113,6 +118,8 @@ int main(int argc, char **argv) {
   bool reverse_plot_direction_option = false;
   bool encode_decode_timer_option_set = false;
   bool show_gpu_info_bar = false;
+  bool show_extra_clocks_bar = false;
+  bool show_all_clocks_bar = false;
   bool show_snapshot = false;
   bool loop_snapshot = false;
   double encode_decode_hide_time = -1.;
@@ -158,6 +165,12 @@ int main(int argc, char **argv) {
       break;
     case 'i':
       show_gpu_info_bar = true;
+      break;
+    case 'x':
+      show_extra_clocks_bar = true;
+      break;
+    case 'X':
+      show_all_clocks_bar = true;
       break;
     case 'E': {
       if (sscanf(optarg, "%lf", &encode_decode_hide_time) == EOF) {
@@ -307,6 +320,8 @@ int main(int argc, char **argv) {
   if (update_interval_option_set)
     allDevicesOptions.update_interval = update_interval_option;
   allDevicesOptions.has_gpu_info_bar = allDevicesOptions.has_gpu_info_bar || show_gpu_info_bar;
+  allDevicesOptions.has_extra_clocks_bar = allDevicesOptions.has_extra_clocks_bar || show_extra_clocks_bar;
+  allDevicesOptions.has_all_clocks_bar = allDevicesOptions.has_all_clocks_bar || show_all_clocks_bar;
 
   gpuinfo_populate_static_infos(&monitoredGpus);
   unsigned numMonitoredGpus =


### PR DESCRIPTION
NVML reports the graphics, memory and video clocks and nothing else, so on NVIDIA the domains that explain much of what the GPU is doing under a power limit are invisible to nvtop. XBAR in particular is the clock the memory subsystem runs at, and watching it next to the graphics clock is what tells a power limited board apart from a bandwidth limited one.

They are reachable through the NvAPI library the driver installs next to NVML. Everything is resolved through `nvapi_QueryInterface`, so a driver without the library, or without these entry points, simply reports no extra clocks and nothing else in the interface changes. **No privileges are needed** - this works as an ordinary user, same as NVML.

### Screenshot

`nvtop -x`, on an idle and a loaded GPU:

```
 Device 0 [NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition] PCIe GEN 4@16x
 GPU 2422MHz MEM 16000MHz TEMP  41°C  FAN   0%   POW 251 / 250 W
 GPU[|||||||||||||||||||||||||||||||||||||100%(eff 100%)] MEM[||||||  11.908Gi/95.593Gi]
 XBAR 1980MHz    SYS 1980MHz     NVD 1395MHz

 Device 1 [NVIDIA RTX PRO 6000 Blackwell Max-Q Workstation Edition] PCIe GEN 1@16x
 GPU 675MHz  MEM 405MHz   TEMP  22°C  FAN   0%   POW   9 / 250 W
 GPU[                                         0%(eff 0%)] MEM[   0.596Gi/95.593Gi]
 XBAR 885MHz     SYS 660MHz      NVD 930MHz
```

### Not an NVIDIA specific field

The dynamic info carries these as a small array of named domains rather than as three NVIDIA specific fields, since other drivers expose clocks of the same kind - `socclk` and `fclk` on AMD, for instance - and can fill the same array with a single call to `gpuinfo_add_extra_clock()`.

A domain can be marked secondary, meaning it sits at a fixed frequency most of the time and is only worth a look now and then. `-x` shows the rest, `-X` shows both, and both have a checkbox in the setup window under Devices. The snapshot output carries every domain a device reports, keyed by name.

### The bar costs nothing when there is nothing to show

How many domains a GPU reports is only known after its first refresh, which happens once the windows have already been laid out. So the rows the bar needs are recomputed on every draw and the windows rebuilt when the count changes. A GPU that reports no such domain - an AMD or Intel one, or an NVIDIA whose driver has no NvAPI - costs no row at all rather than leaving a blank line, and the bar takes a second row when eight domains are on screen.

Rows are never given back on their own, only when an option changes, so one failed read cannot make the interface jump. The rebuild is also held back while the setup window is open, since `alloc_setup_window()` clears `visible` and would otherwise close it under the user mid-toggle.

### Testing

Six GPUs on one machine, driver 610.57.04: three RTX PRO 6000 Blackwell, an RTX PRO 4000 Blackwell, an RTX 2000 Ada and a GeForce RTX 3060 Ti, plus a Ryzen 9900X integrated GPU for the case where a device reports nothing. Ada and Ampere work as well as Blackwell, so this is not new hardware only.

The struct layout was checked against `nvidia-smi` before being trusted: domain 0 matches `clocks.current.graphics`, domain 4 matches `clocks.current.memory` and domain 21 matches `clocks.current.video`, exactly, on all six.

Verified: both options separately and together, alongside `-i`, toggling from the setup window, saving and reloading the config, a config that leaves only the integrated GPU monitored (no row reserved), and the snapshot output. Builds clean with `-Wall -Wextra`.
