### PR TITLE
Remote GPU telemetry: monitor your whole GPU fleet from one nvtop

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,15 @@ option(ENFLAME_SUPPORT "Build support for Enflame GCUs through libefml" ${ENFLAM
 option(TENSTORRENT_SUPPORT "Build support for Tenstorrent accelerators through tt-kmd" ${TENSTORRENT_SUPPORT_DEFAULT})
 option(IXML_SUPPORT "Build support for Iluvatar CoreX GPUs through libixml" ${IXML_SUPPORT_DEFAULT})
 
+# Remote GPU telemetry (nvtop --export server + remote vendor) is
+# available on any POSIX platform with sockets in libc.
+if (CMAKE_SYSTEM_NAME STREQUAL "Linux")
+  set(REMOTE_SUPPORT_DEFAULT ON)
+else()
+  set(REMOTE_SUPPORT_DEFAULT OFF)
+endif()
+option(REMOTE_SUPPORT "Build support for remote GPU telemetry over TCP (nvtop --export)" ${REMOTE_SUPPORT_DEFAULT})
+
 add_subdirectory(src)
 
 #///////////////////////////////////////////////////////////////////#

--- a/example.md
+++ b/example.md
@@ -1,0 +1,321 @@
+# nvtop Remote GPU Telemetry — Complete Reference & Examples
+
+This document is the single place to learn the **remote GPU** feature:
+what it is, how it works at the wire level, how to deploy a whole-fleet
+dashboard, and every command and config knob involved. If you run GPUs on
+several machines and want **one** nvtop screen to show them all, start
+here.
+
+---
+
+## 1. What this is
+
+nvtop can now talk to itself across the network. Two roles:
+
+| Role | Command | What it does |
+|------|---------|--------------|
+| **Exporter** (runs on each remote GPU host) | `nvtop --export [port]` | Headless TCP server that serves this host's live GPU stats to any consumer that polls it. |
+| **Dashboard / consumer** (runs on one host) | `nvtop` (with `[RemoteHost]` INI sections) | Dials each exporter and renders every remote GPU as a normal nvtop device, next to local GPUs. |
+
+The result: a **single dashboard** aggregating a heterogeneous fleet
+(workstations, GPU nodes, Docker containers) — live utilization, memory,
+clocks, temperature, power, and per-GPU processes.
+
+---
+
+## 2. Architecture
+
+```
+                         +--------------------------------------+
+                         |   DASHBOARD HOST (consumer)          |
+                         |   runs: nvtop  (interactive)        |
+                         |   config: [RemoteHost] x N           |
+                         +-------------------+------------------+
+                                           |  dials each exporter
+        +----------------+    TCP:8765     v
+        | GPU HOST A     |   NVT1 frames   +--------------------------------------+
+        | nvtop --export| ----------------> gpu_vendor_remote renders
+        | (exporter)    |   POLL -> frame |  each remote GPU as a normal device   |
+        +----------------+                 +--------------------------------------+
+```
+
+Each **exporter** runs headless on a GPU machine. Each **dashboard** host
+has one or more `[RemoteHost]` sections pointing at those exporters. The
+remote GPU appears in nvtop with a synthetic device id `R<hostIdx>_<gpuIdx>`,
+so it shows up alongside local GPUs in the same plots and tables.
+
+---
+
+## 3. The NVT1 wire protocol
+
+A snapshot is a single length-prefixed TCP message:
+
+```
++----------------+--------------------------------------------------+
+| 4-byte length  |  payload (little-endian)                         |
+| (big-endian)   |                                                  |
++----------------+--------------------------------------------------+
+payload layout:
+  [wire_header]
+  [wire_static  x static_count]
+  [ (wire_gpu + wire_process x process_count)  x gpu_count ]
+
+wire_header (14 bytes):
+  magic "NVT1" (4) | proto_major(1) | proto_minor(1) |
+  flags(1) | static_count(1) | gpu_count(2, LE) | reserved(4)
+  (flags bit 0 set => payload integers are little-endian)
+```
+
+**Key properties**
+
+- The **length prefix is big-endian**; **all payload integers are
+  little-endian** (the header `flags` byte declares this).
+- `valid[]` bitmaps in `wire_gpu` / `wire_static` / `wire_process` are
+  forwarded **verbatim**, so a consumer renders absent fields as N/A
+  with zero extra logic.
+- The consumer (dashboard) uses a **900 ms cache + last-good fallback**:
+  it only re-dials when the cache is stale, and if a host goes down the
+  last successfully-read frame keeps showing, so a dead host never stalls
+  the UI.
+
+`remote_wire_decode()` validates: correct magic, `proto_major <= 1`,
+`static_count <= 1`, `gpu_count <= 16`, and that the frame size matches
+the declared length — otherwise it returns 0 (rejects the frame).
+
+---
+
+## 4. Commands & flags
+
+### Exporter side (remote GPU host)
+
+```bash
+nvtop --export              # headless exporter on default port 8765
+nvtop --export 9100         # custom port
+nvtop --export --bind 10.0.0.1   # bind to a specific address (default 0.0.0.0)
+nvtop --export 8765 -d 5    # 500ms refresh cadence (tenths of a second)
+```
+
+- `--export [port]` — start the headless exporter. Optional port, default
+  `8765`. This process runs the poll/encode loop; it does **not** open a
+  TUI.
+- `--bind <addr>` — address the exporter binds to (default `0.0.0.0`).
+- `-d / --delay` — refresh cadence in tenths of a second (the exporter's
+  loop uses this for `gpuinfo_refresh_dynamic_info` cadence).
+
+### Dashboard / consumer side
+
+```bash
+nvtop                        # interactive UI; remote hosts from INI [RemoteHost]
+nvtop -s                    # one-shot snapshot (scripting)
+nvtop -l                    # looping snapshot
+nvtop -c /path/to/ini       # point at a specific config file
+```
+
+Remote hosts are **not** a command-line flag — they come from the
+`[RemoteHost]` INI sections described below. The dashboard dials each one
+on its 900 ms cache.
+
+### Related nvtop flags (full reference)
+
+| Flag | Long | Meaning |
+|------|------|---------|
+| `-d N` | `--delay` | Refresh interval in tenths of a second |
+| `-v` | `--version` | Print version |
+| `-h` | `--help` | Print help |
+| `-c <file>` | `--config` | Use a specific config file |
+| `-C` | `--no-color` | Disable colors |
+| `-f` | `--fahrenheit` | Temperature in Fahrenheit |
+| `-i` | `--gpu-info` | Show the GPU info bar |
+| `-E <secs>` | `--encode-hide` | Hide encode/decode after N seconds |
+| `-p` | `--no-plot` | Hide plots |
+| `-P` | `--no-processes` | Hide process list |
+| `-r` | `--reverse-abs` | Reverse plot direction |
+| `-s` | `--snapshot` | One-shot stats, no ncurses |
+| `-l` | `--loop` | Looping stats, no ncurses |
+| `-x [port]` | `--export` | **Headless TCP exporter** (default port 8765) |
+| `-b <addr>` | `--bind` | **Bind address** for `--export` (default 0.0.0.0) |
+
+---
+
+## 5. Configuration
+
+Remote hosts live in the **existing** nvtop INI file — the same file that
+holds your plot/process preferences. Default path:
+`~/.config/nvtop/interface.ini` (overridable with `-c`).
+
+```ini
+# ~/.config/nvtop/interface.ini
+
+[RemoteHost]
+Host = remote-gpu-host-1
+Port = 8765
+Name = GPU Node 1
+
+[RemoteHost]
+Host = remote-gpu-host-2
+Port = 8765
+Name = GPU Node 2
+```
+
+- `Host` — remote host (hostname or IP). **Required** (a block without it is
+  skipped).
+- `Port` — exporter port. **Optional**, defaults to `8765`.
+- `Name` — label shown in the UI. **Optional**, defaults to the host value.
+
+The INI parser must be built with `INI_CALL_HANDLER_ON_NEW_SECTION=1`
+(handled automatically by `src/CMakeLists.txt` when `REMOTE_SUPPORT` is on),
+because a new section header must fire the handler so each `[RemoteHost]`
+block gets committed. Without it, no remote host is ever registered and the
+dashboard sees zero remote GPUs.
+
+---
+
+## 6. End-to-end example (a 3-GPU fleet)
+
+The worked example below mirrors a real mixed fleet: a local workstation
+GPU, a GPU node, and a containerized GPU.
+
+### Step 1 — Build nvtop with remote support
+
+```bash
+# From the repo root
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DREMOTE_SUPPORT=ON
+cmake --build build
+```
+
+`REMOTE_SUPPORT` defaults to **ON on Linux**, OFF elsewhere.
+
+### Step 2 — Run an exporter on each remote GPU host
+
+On **GPU Node 1** (e.g. a bare-metal or Docker host with an NVIDIA GPU):
+
+```bash
+# systemd service (recommended for headless operation)
+nvtop --export 8765 --bind 0.0.0.0
+```
+
+Or as a systemd unit:
+
+```ini
+# /etc/systemd/system/nvtop-exporter.service
+[Unit]
+Description=nvtop GPU telemetry exporter (NVT1)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+ExecStart=/usr/local/bin/nvtop --export=8765
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+```
+
+In **Docker** (NVIDIA runtime):
+
+```yaml
+# docker-compose.yml
+services:
+  nvtop-exporter:
+    image: ubuntu:24.04
+    command: ["/nvtop/nvtop", "--export=8765"]
+    ports:
+      - "8765:8765"
+    volumes:
+      - ./nvtop:/nvtop:ro
+    runtime: nvidia
+    environment:
+      - NVIDIA_VISIBLE_DEVICES=all
+    restart: unless-stopped
+```
+
+### Step 3 — Point the dashboard at the exporters
+
+On the **dashboard** host, edit `~/.config/nvtop/interface.ini`:
+
+```ini
+[RemoteHost]
+Host = 10.0.0.11
+Port = 8765
+Name = GPU Node 1
+
+[RemoteHost]
+Host = 10.0.0.12
+Port = 8765
+Name = GPU Node 2
+```
+
+Then simply run:
+
+```bash
+nvtop
+```
+
+Every remote GPU now appears in the same plots/tables as your local GPUs.
+If a remote host is unreachable, its last-known values keep displaying
+(last-good fallback) rather than vanishing.
+
+### Step 4 — Verify an exporter responds (scripting)
+
+```python
+import socket, struct
+
+def poll(host, port=8765):
+    s = socket.socket()
+    s.settimeout(5)
+    s.connect((host, port))
+    s.sendall(b'\x01')                      # the POLL byte
+    hdr = s.recv(4)
+    if len(hdr) < 4:
+        s.close(); raise SystemExit('short header')
+    length = struct.unpack('>I', hdr)[0]     # big-endian length
+    body = b''
+    while len(body) < length:
+        chunk = s.recv(length - len(body))
+        if not chunk:
+            raise SystemExit('connection closed mid-frame')
+        body += chunk
+    s.close()
+    # header: magic(4) major(1) minor(1) flags(1) static_count(1) gpu_count(2 LE) reserved(4)
+    print('magic =', body[:4].decode('latin1'))
+    print('gpu_count =', struct.unpack('<H', body[8:10])[0])
+    print('payload bytes =', length)
+    return body
+
+poll('10.0.0.11')
+```
+
+Expected: `magic = NVT1`, `gpu_count` = number of GPUs on that host, and
+`payload` = frame size in bytes.
+
+---
+
+## 7. Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Dashboard shows only local GPUs | No `[RemoteHost]` sections parsed | Build with `REMOTE_SUPPORT` (enables `INI_CALL_HANDLER_ON_NEW_SECTION`); add the INI sections |
+| A remote GPU's stats freeze at a stale value | That host's exporter went down | The last-good fallback keeps the last frame; restart the exporter on that host |
+| Exporter prints `could not bind the export server on port N` | Port already in use | Kill the stale process or pick another port |
+| Poll times out | Exporter running but not encoding | Give the exporter's 100 ms refresh loop a moment; poll in a retry loop |
+| A container's exporter accepts connections but returns no frame | Container runs a stale binary | Rebuild and redeploy the new binary into the container |
+| Firewall blocks 8765 | Inbound rule missing on the remote host | Allow TCP 8765 (e.g. Windows inbound rule / `ufw allow 8765`) |
+
+---
+
+## 8. Build options
+
+```bash
+# Enable / disable remote telemetry
+-DREMOTE_SUPPORT=ON|OFF        # default: ON on Linux, OFF otherwise
+
+# Turn on the wire round-trip GTest suite
+-DBUILD_TESTING=ON            # builds tests/wireTest.cpp (remote_wire tests)
+```
+
+The wire codec is covered by `tests/wireTest.cpp`:
+- `RemoteWire.RoundTrip` — encode → decode a multi-GPU, multi-process
+  snapshot and assert every field and the `valid[]` bits survive.
+- `RemoteWire.TruncatedBufferReturnsError` — a frame shorter than the
+  declared length, or a clobbered magic, must be rejected (decode returns 0).

--- a/include/nvtop/export_server.h
+++ b/include/nvtop/export_server.h
@@ -1,0 +1,50 @@
+/*
+ *
+ * Copyright (C) 2026 Nvtop contributors
+ *
+ * This file is part of Nvtop.
+ *
+ * Nvtop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nvtop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with nvtop.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef NVTOP_EXPORT_SERVER_H__
+#define NVTOP_EXPORT_SERVER_H__
+
+#include <stdbool.h>
+
+#include "list.h"
+
+/*
+ * nvtop --export server: a single-client TCP listener that serves one
+ * length-prefixed NVT1 frame per POLL byte written by the consumer.
+ *
+ * All socket I/O happens on the main thread (nvtop is single-threaded),
+ * so no locks are needed. The consumer sends exactly one POLL byte per
+ * refresh; the server serializes the current monitored GPU list into a
+ * frame and ships it back.
+ */
+
+/* Register the device list to serialize; call before start. */
+void export_server_init(struct list_head *monitored_gpus);
+
+/* Open the TCP listener. Returns 0 on success, -1 on error. */
+int export_server_start(unsigned short port, const char *bind_addr);
+
+/* Non-blocking: if a POLL byte is waiting, serve one frame and return 1. */
+bool export_server_poll(void);
+
+/* Close the listener + client, reset state. */
+void export_server_stop(void);
+
+#endif // NVTOP_EXPORT_SERVER_H__

--- a/include/nvtop/remote_proto.h
+++ b/include/nvtop/remote_proto.h
@@ -1,0 +1,173 @@
+/*
+ *
+ * Copyright (C) 2026 Nvtop contributors
+ *
+ * This file is part of Nvtop.
+ *
+ * Nvtop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nvtop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with nvtop.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#ifndef NVTOP_REMOTE_PROTO_H__
+#define NVTOP_REMOTE_PROTO_H__
+
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "extract_gpuinfo_common.h"
+#include "list.h"
+#include "time.h"
+
+/*
+ * Remote GPU telemetry wire protocol ("NVT1").
+ *
+ * A snapshot frame is one length-prefixed message:
+ *
+ *   [4-byte big-endian total_len]
+ *   [wire_header]
+ *   [wire_static * static_count]
+ *   [ (wire_gpu + wire_process * process_count) * gpu_count ]
+ *
+ * All multi-byte integers in the payload are explicit little-endian;
+ * the length prefix is big-endian (RFC 768 style). The `valid[]`
+ * bitmaps are forwarded verbatim so the client can render absent
+ * fields as N/A with zero extra logic.
+ */
+
+#define NVTOP_EXPORT_DEFAULT_PORT 8765
+#define NVTOP_EXPORT_MAGIC "NVT1"
+
+#define NVTOP_REMOTE_CACHE_NS (900 * 1000 * 1000) // 900ms
+
+#define REMOTE_NAME_LEN 64
+#define REMOTE_HOST_LEN 64
+#define REMOTE_CMDLINE_LEN 512
+
+enum remote_proto_version {
+  remote_proto_major = 1,
+  remote_proto_minor = 0,
+};
+
+/* flags bit 0 set => payload integers are little-endian */
+struct wire_header {
+  char magic[4];
+  uint8_t proto_major;
+  uint8_t proto_minor;
+  uint8_t flags;
+  uint8_t static_count;
+  uint16_t gpu_count;
+  uint32_t reserved;
+};
+
+struct wire_static {
+  char device_name[MAX_DEVICE_NAME];
+  uint32_t max_pcie_gen;
+  uint32_t max_pcie_link_width;
+  uint32_t temperature_shutdown_threshold;
+  uint32_t temperature_slowdown_threshold;
+  uint32_t n_shared_cores;
+  uint32_t l2cache_size;
+  uint32_t n_exec_engines;
+  uint32_t engine_count;
+  uint8_t integrated_graphics;
+  uint8_t encode_decode_shared;
+  uint8_t valid[(gpuinfo_static_info_count + CHAR_BIT - 1) / CHAR_BIT];
+};
+
+struct wire_gpu {
+  uint32_t gpu_clock_speed;
+  uint32_t gpu_clock_speed_max;
+  uint32_t mem_clock_speed;
+  uint32_t mem_clock_speed_max;
+  uint32_t gpu_util_rate;
+  uint32_t mem_util_rate;
+  uint32_t effective_load_rate;
+  uint32_t encoder_rate;
+  uint32_t decoder_rate;
+  uint64_t total_memory;
+  uint64_t free_memory;
+  uint64_t used_memory;
+  uint32_t pcie_link_gen;
+  uint32_t pcie_link_width;
+  uint32_t pcie_rx;
+  uint32_t pcie_tx;
+  uint32_t fan_speed;
+  uint32_t fan_rpm;
+  uint32_t gpu_temp;
+  uint32_t power_draw;
+  uint32_t power_draw_max;
+  uint8_t multi_instance_mode;
+  uint8_t valid[(gpuinfo_dynamic_info_count + CHAR_BIT - 1) / CHAR_BIT];
+  uint16_t process_count;
+};
+
+struct wire_process {
+  uint32_t type;
+  uint32_t pid;
+  char cmdline[REMOTE_CMDLINE_LEN];
+  char user_name[REMOTE_NAME_LEN];
+  uint64_t sample_delta;
+  uint64_t gfx_engine_used;
+  uint64_t compute_engine_used;
+  uint64_t enc_engine_used;
+  uint64_t dec_engine_used;
+  uint64_t gpu_cycles;
+  uint32_t gpu_usage;
+  uint32_t encode_usage;
+  uint32_t decode_usage;
+  uint64_t gpu_memory_usage;
+  uint32_t gpu_memory_percentage;
+  uint32_t cpu_usage;
+  uint64_t cpu_memory_virt;
+  uint64_t cpu_memory_res;
+  uint8_t valid[(gpuinfo_process_info_count + CHAR_BIT - 1) / CHAR_BIT];
+};
+
+struct remote_host {
+  struct list_head list;
+  char name[REMOTE_NAME_LEN];
+  char host[REMOTE_HOST_LEN];
+  unsigned short port;
+  int sock;
+  nvtop_time last_refresh, last_success;
+  unsigned gpu_count;
+  struct gpu_info_remote *gpus;
+  struct wire_gpu *last_good;
+  unsigned last_good_capacity;
+  struct wire_static *last_good_static;
+  struct wire_process *last_good_procs;
+  unsigned last_good_procs_capacity;
+  bool has_data;
+};
+
+struct gpu_info_remote {
+  struct gpu_info base;
+  struct remote_host *host;
+  unsigned host_idx;
+  unsigned gpu_idx;
+};
+
+/* Encode the current monitored GPU list into one length-prefixed frame.
+ * The 4-byte length prefix + payload occupies `total_len` bytes; the caller
+ * supplies `out` with `total_len + 4` bytes. Returns the payload size on
+ * success, 0 on error. */
+size_t remote_wire_encode(struct list_head *monitored_gpus, uint8_t *out, size_t out_size);
+
+/* Decode one frame (the 4-byte length prefix + payload) into caller-provided
+ * arrays. Returns the number of GPUs on success, 0 on error. */
+unsigned remote_wire_decode(const uint8_t *frame, size_t frame_size, struct wire_static *statics,
+                            struct wire_gpu *gpus, struct wire_process *procs);
+
+#endif // NVTOP_REMOTE_PROTO_H__

--- a/manpage/nvtop.in
+++ b/manpage/nvtop.in
@@ -41,6 +41,22 @@ Show only one bar plot corresponding to the maximum of all GPUs.
 .TP
 .BR \-v ", " \-\-version
 Print the version and exit.
+.TP
+.BR \-s ", " \-\-snapshot
+Output the current gpu stats without ncurses (useful for scripting).
+.TP
+.BR \-l ", " \-\-loop
+Output the current gpu stats without ncurses in a loop.
+.TP
+.BR \-x ", " \-\-export \fI[port]\fR
+Serve the current gpu stats to remote consumers over TCP on the given
+port (default 8765). Pair with \fB\-b \-\-bind\fR \fIaddr\fR to change the
+bind address (default 0.0.0.0). Intended for running headless as a
+systemd service on remote hosts; the dashboard host then lists them via
+the \fB[RemoteHost]\fR configuration section.
+.TP
+.BR \-b ", " \-\-bind \fIaddr\fR
+Address the \fB\-\-export\fR server binds to (default \fI0.0.0.0\fR).
 
 .SH INTERACTIVE SETUP WINDOW
 .TP

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -159,6 +159,15 @@ if(METAX_SUPPORT)
   target_sources(nvtop PRIVATE extract_gpuinfo_metax.c)
 endif()
 
+if(REMOTE_SUPPORT)
+  message(STATUS "Building with remote GPU telemetry support (--export / [RemoteHost])")
+  target_compile_definitions(nvtop PRIVATE REMOTE_SUPPORT=1 INI_CALL_HANDLER_ON_NEW_SECTION=1)
+  target_sources(nvtop PRIVATE
+    extract_gpuinfo_remote.c
+    export_server.c
+    remote_wire.c)
+endif()
+
 if(ENFLAME_SUPPORT)
   message(STATUS "Building with Enflame GCU support")
   target_sources(nvtop PRIVATE extract_gcuinfo_enflame.c)

--- a/src/export_server.c
+++ b/src/export_server.c
@@ -1,0 +1,167 @@
+/*
+ *
+ * Copyright (C) 2026 Nvtop contributors
+ *
+ * This file is part of Nvtop.
+ *
+ * Nvtop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nvtop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with nvtop.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "nvtop/export_server.h"
+#include "nvtop/remote_proto.h"
+
+#include <arpa/inet.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <netinet/in.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <sys/time.h>
+#include <unistd.h>
+
+static struct list_head *monitored_gpus;
+static int listen_sock = -1;
+static int client_sock = -1;
+static uint8_t *frame_buf;
+static size_t frame_buf_size = 0;
+
+void export_server_init(struct list_head *monitored_gpus_ptr) {
+  monitored_gpus = monitored_gpus_ptr;
+  client_sock = -1;
+}
+
+int export_server_start(unsigned short port, const char *bind_addr) {
+  struct sockaddr_in addr;
+  int opt = 1;
+
+  listen_sock = socket(AF_INET, SOCK_STREAM, 0);
+  if (listen_sock < 0) return -1;
+  setsockopt(listen_sock, SOL_SOCKET, SO_REUSEADDR, &opt, sizeof(opt));
+
+  memset(&addr, 0, sizeof(addr));
+  addr.sin_family = AF_INET;
+  addr.sin_port = htons(port);
+  if (bind_addr && strlen(bind_addr) > 0) {
+    if (inet_pton(AF_INET, bind_addr, &addr.sin_addr) != 1) {
+      close(listen_sock);
+      listen_sock = -1;
+      return -1;
+    }
+  } else {
+    addr.sin_addr.s_addr = INADDR_ANY;
+  }
+  if (bind(listen_sock, (struct sockaddr *)&addr, sizeof(addr)) != 0) {
+    close(listen_sock);
+    listen_sock = -1;
+    return -1;
+  }
+  if (listen(listen_sock, 8) != 0) {
+    close(listen_sock);
+    listen_sock = -1;
+    return -1;
+  }
+  fcntl(listen_sock, F_SETFL, fcntl(listen_sock, F_GETFL, 0) | O_NONBLOCK);
+  return 0;
+}
+
+/* Serve exactly one POLL: read 1 byte, encode the current device list,
+ * and send the length-prefixed frame. Returns true if a frame was sent. */
+bool export_server_poll(void) {
+  if (listen_sock < 0) return false;
+
+  /* Accept a new client if one is waiting (non-blocking). */
+  if (client_sock < 0) {
+    struct sockaddr_in client_addr;
+    socklen_t addr_len = sizeof(client_addr);
+    client_sock = accept(listen_sock, (struct sockaddr *)&client_addr, &addr_len);
+    if (client_sock >= 0) {
+      /* Use a blocking socket with SO_RCVTIMEO/SO_SNDTIMEO for timeouts,
+       * and SO_LINGER so close() flushes the send buffer. */
+      struct timeval tv = {1, 0};
+      setsockopt(client_sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+      setsockopt(client_sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+      /* Force close() to flush the send buffer before tearing down, so a
+       * consumer reading the frame receives every byte. */
+      struct linger lg = {1, 30};
+      setsockopt(client_sock, SOL_SOCKET, SO_LINGER, &lg, sizeof(lg));
+    }
+  }
+  if (client_sock < 0) return false;
+
+  uint8_t poll_byte;
+  ssize_t n = recv(client_sock, &poll_byte, 1, 0);
+  while (n < 0 && (errno == EAGAIN || errno == EWOULDBLOCK)) {
+    struct timespec ts = {0, 50 * 1000 * 1000};
+    nanosleep(&ts, NULL);
+    n = recv(client_sock, &poll_byte, 1, 0);
+  }
+  /* Client closed the connection (recv returned 0) or errored: tear down
+   * the socket so the next client can be accepted. Without this, a stale
+   * connection holds client_sock and blocks all subsequent POLLs. */
+  if (n == 0) {
+    close(client_sock);
+    client_sock = -1;
+    return false;
+  }
+  if (n != 1) return false;
+
+  /* Encode the current snapshot into the frame buffer. */
+  if (!frame_buf) {
+    frame_buf_size = 1 << 16;
+    frame_buf = (uint8_t *)malloc(frame_buf_size);
+  }
+  size_t frame_len = remote_wire_encode(monitored_gpus, frame_buf, frame_buf_size);
+  if (frame_len == 0) return false;
+  if (frame_len + 4 > frame_buf_size) return false;
+
+  const uint8_t *p = frame_buf;
+  size_t total = frame_len + 4;
+  while (total > 0) {
+    ssize_t sent = send(client_sock, p, total, MSG_NOSIGNAL);
+    if (sent > 0) {
+      p += sent;
+      total -= (size_t)sent;
+    } else if (sent == 0) {
+      close(client_sock);
+      client_sock = -1;
+      return false;
+    } else {
+      if (errno != EAGAIN && errno != EWOULDBLOCK) {
+        close(client_sock);
+        client_sock = -1;
+        return false;
+      }
+      struct timespec ts = {0, 50 * 1000 * 1000};
+      nanosleep(&ts, NULL);
+    }
+  }
+  /* close() with SO_LINGER flushes the send buffer before tearing down,
+   * so the consumer receives every byte of the frame. Then reset
+   * client_sock so the next poller's connection is accepted. */
+  close(client_sock);
+  client_sock = -1;
+  return true;
+}
+
+void export_server_stop(void) {
+  if (client_sock >= 0) {
+    close(client_sock);
+    client_sock = -1;
+  }
+  if (listen_sock >= 0) {
+    close(listen_sock);
+    listen_sock = -1;
+  }
+}

--- a/src/extract_gpuinfo_remote.c
+++ b/src/extract_gpuinfo_remote.c
@@ -1,0 +1,511 @@
+/*
+ *
+ * Copyright (C) 2026 Nvtop contributors
+ *
+ * This file is part of Nvtop.
+ *
+ * Nvtop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nvtop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with nvtop.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "ini.h"
+#include "nvtop/extract_gpuinfo_common.h"
+#include "nvtop/remote_proto.h"
+#include "nvtop/time.h"
+
+#include <arpa/inet.h>
+#include <netdb.h>
+#include <netinet/in.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/socket.h>
+#include <time.h>
+#include <unistd.h>
+
+/*
+ * Remote GPU vendor: dials remote nvtop exporters (see --export) and
+ * renders each remote GPU as a regular `gpu_info` node, mirroring the
+ * TPU backend's 900 ms cache + last-good fallback so a dead host never
+ * stalls the UI.
+ *
+ * Configuration comes from the existing nvtop INI file (XDG or -c
+ * override): repeating `[RemoteHost]` sections:
+ *
+ *   [RemoteHost]
+ *   Host = remote-gpu-host-1
+ *   Port = 8765
+ *   Name = Host 1
+ *
+ *   [RemoteHost]
+ *   Host = remote-gpu-host-2
+ *   Name = Host 2
+ */
+
+static struct remote_host **remote_hosts;
+static unsigned remote_host_count;
+static struct list_head remote_host_list;
+
+/* vtable callbacks */
+static bool gpuinfo_remote_init(void);
+static void gpuinfo_remote_shutdown(void);
+static const char *gpuinfo_remote_last_error_string(void);
+static bool gpuinfo_remote_get_device_handles(struct list_head *devices, unsigned *count);
+static void gpuinfo_remote_populate_static_info(struct gpu_info *_gpu_info);
+static void gpuinfo_remote_refresh_dynamic_info(struct gpu_info *_gpu_info);
+static void gpuinfo_remote_refresh_running_processes(struct gpu_info *_gpu_info);
+
+struct gpu_vendor gpu_vendor_remote = {
+  .init = gpuinfo_remote_init,
+  .shutdown = gpuinfo_remote_shutdown,
+  .last_error_string = gpuinfo_remote_last_error_string,
+  .get_device_handles = gpuinfo_remote_get_device_handles,
+  .populate_static_info = gpuinfo_remote_populate_static_info,
+  .refresh_dynamic_info = gpuinfo_remote_refresh_dynamic_info,
+  .refresh_running_processes = gpuinfo_remote_refresh_running_processes,
+  .name = "Remote",
+};
+
+__attribute__((constructor)) static void init_extract_gpuinfo_remote(void) {
+  register_gpu_vendor(&gpu_vendor_remote);
+}
+
+/* INI handler: collect [RemoteHost] sections */
+
+/* struct remote_host is defined in nvtop/remote_proto.h */
+
+struct remote_ini_ctx {
+  char pending_name[REMOTE_NAME_LEN];
+  char pending_host[REMOTE_HOST_LEN];
+  unsigned short pending_port;
+};
+
+static void remote_host_commit(struct remote_ini_ctx *c) {
+  if (!c->pending_host[0])
+    return;
+  struct remote_host *h = (struct remote_host *)calloc(1, sizeof(*h));
+  if (!h)
+    return;
+  snprintf(h->name, sizeof(h->name), "%s", c->pending_name[0] ? c->pending_name : c->pending_host);
+  snprintf(h->host, sizeof(h->host), "%s", c->pending_host);
+  h->port = c->pending_port ? c->pending_port : NVTOP_EXPORT_DEFAULT_PORT;
+  h->sock = -1;
+  h->gpu_count = 0;
+  h->gpus = NULL;
+  h->last_good = (struct wire_gpu *)calloc(8, sizeof(struct wire_gpu));
+  h->last_good_static = (struct wire_static *)calloc(1, sizeof(struct wire_static));
+  h->last_good_procs = (struct wire_process *)calloc(64, sizeof(struct wire_process));
+  h->has_data = false;
+  list_add_tail(&h->list, &remote_host_list);
+  remote_host_count++;
+  remote_hosts = (struct remote_host **)realloc(remote_hosts, remote_host_count * sizeof(*remote_hosts));
+  remote_hosts[remote_host_count - 1] = h;
+  c->pending_name[0] = '\0';
+  c->pending_host[0] = '\0';
+  c->pending_port = 0;
+}
+
+static int remote_ini_handler(void *ctx, const char *section, const char *name, const char *value) {
+  struct remote_ini_ctx *c = (struct remote_ini_ctx *)ctx;
+  if (!section)
+    return true;
+  if (strcmp(section, "RemoteHost") != 0) {
+    /* A new non-RemoteHost section ends the previous [RemoteHost] block */
+    remote_host_commit(c);
+    return true;
+  }
+  if (name && value) {
+    if (strcmp(name, "Name") == 0) {
+      snprintf(c->pending_name, sizeof(c->pending_name), "%s", value);
+    } else if (strcmp(name, "Host") == 0) {
+      snprintf(c->pending_host, sizeof(c->pending_host), "%s", value);
+    } else if (strcmp(name, "Port") == 0) {
+      c->pending_port = (unsigned short)strtol(value, NULL, 10);
+    }
+    return true;
+  }
+  /* [RemoteHost] header line: commit any previously accumulated block */
+  remote_host_commit(c);
+  return true;
+}
+
+/* Connect to a host with a short timeout so a dead host never stalls the
+ * UI. Returns the socket fd or -1. */
+static int remote_host_connect(struct remote_host *h) {
+  struct addrinfo hints, *res = NULL;
+  char port_str[8];
+  int sock = -1;
+
+  memset(&hints, 0, sizeof(hints));
+  hints.ai_family = AF_UNSPEC;
+  hints.ai_socktype = SOCK_STREAM;
+  snprintf(port_str, sizeof(port_str), "%u", h->port);
+  if (getaddrinfo(h->host, port_str, &hints, &res) != 0 || !res)
+    return -1;
+
+  for (struct addrinfo *ai = res; ai; ai = ai->ai_next) {
+    sock = socket(ai->ai_family, ai->ai_socktype, ai->ai_protocol);
+    if (sock < 0)
+      continue;
+    struct timeval tv = {0, 150 * 1000 * 1000}; /* 150 ms */
+    setsockopt(sock, SOL_SOCKET, SO_SNDTIMEO, &tv, sizeof(tv));
+    setsockopt(sock, SOL_SOCKET, SO_RCVTIMEO, &tv, sizeof(tv));
+    if (connect(sock, ai->ai_addr, ai->ai_addrlen) == 0)
+      break;
+    close(sock);
+    sock = -1;
+  }
+  freeaddrinfo(res);
+  return sock;
+}
+
+/* Pull one frame: send 1 POLL byte, read the length-prefixed frame, and
+ * store it as last-good. Returns true on success. */
+static bool remote_host_refresh(struct remote_host *h) {
+  if (h->sock < 0) {
+    h->sock = remote_host_connect(h);
+    if (h->sock < 0)
+      return false;
+  }
+  if (send(h->sock, "\x01", 1, MSG_NOSIGNAL) != 1) {
+    /* A dead/dropped socket: close and reset so the next refresh re-dials. */
+    close(h->sock);
+    h->sock = -1;
+    return false;
+  }
+
+  uint8_t *buf = (uint8_t *)malloc(1 << 16);
+  if (!buf) {
+    close(h->sock);
+    h->sock = -1;
+    return false;
+  }
+  size_t got = 0;
+  /* Read the 4-byte big-endian length prefix first. */
+  while (got < 4) {
+    ssize_t n = recv(h->sock, buf + got, 4 - got, 0);
+    if (n <= 0) {
+      free(buf);
+      close(h->sock);
+      h->sock = -1;
+      return false;
+    }
+    got += n;
+  }
+  uint32_t len = ((uint32_t)buf[0] << 24) | ((uint32_t)buf[1] << 16) | ((uint32_t)buf[2] << 8) | (uint32_t)buf[3];
+  if (len == 0 || len > (1 << 16)) {
+    free(buf);
+    close(h->sock);
+    h->sock = -1;
+    return false;
+  }
+  got = 4;
+  while (got < 4 + len) {
+    ssize_t n = recv(h->sock, buf + got, 4 + len - got, 0);
+    if (n <= 0) {
+      free(buf);
+      close(h->sock);
+      h->sock = -1;
+      return false;
+    }
+    got += n;
+  }
+
+  /* Decode */
+  /* Ensure per-host buffers exist. The header says how many GPUs this
+   * host reports; resize the last_good arrays to fit (grow-only). */
+  {
+    struct wire_header hdr;
+    memcpy(&hdr, buf + 4, sizeof(hdr));
+    unsigned nc = hdr.gpu_count;
+    if (!h->last_good || h->last_good_capacity < nc) {
+      h->last_good = (struct wire_gpu *)realloc(h->last_good, nc * sizeof(struct wire_gpu));
+      h->last_good_capacity = nc;
+    }
+    if (!h->last_good_static)
+      h->last_good_static = (struct wire_static *)calloc(1, sizeof(struct wire_static));
+    if (!h->last_good_procs || h->last_good_procs_capacity < 64) {
+      h->last_good_procs = (struct wire_process *)calloc(64, sizeof(struct wire_process));
+      h->last_good_procs_capacity = 64;
+    }
+  }
+  unsigned gpu_count = remote_wire_decode(buf, 4 + len, h->last_good_static, h->last_good, h->last_good_procs);
+  if (gpu_count == 0) {
+    free(buf);
+    return false;
+  }
+  h->gpu_count = gpu_count;
+  free(buf);
+
+  nvtop_get_current_time(&h->last_success);
+  h->has_data = true;
+  return true;
+}
+
+static bool remote_cache_valid(struct remote_host *h) {
+  nvtop_time now;
+  nvtop_get_current_time(&now);
+  return nvtop_difftime_u64(h->last_success, now) < NVTOP_REMOTE_CACHE_NS;
+}
+
+/* vtable implementation --------------------------------------------------- */
+
+static bool gpuinfo_remote_init(void) {
+  INIT_LIST_HEAD(&remote_host_list);
+  remote_hosts = NULL;
+  remote_host_count = 0;
+
+  /* Reuse the existing config-file path resolution so the remote host list
+   * lives in the same INI as the rest of the nvtop settings. */
+  struct remote_ini_ctx ctx;
+  memset(&ctx, 0, sizeof(ctx));
+
+  /* The remote host list lives in the same INI as the rest of the nvtop
+   * settings. The path is resolved the same way `interface_options.c`
+   * resolves it: $NVTOP_CONFIG_FILE override, then XDG config dir +
+   * `nvtop/interface.ini`. */
+  char *config_path = getenv("NVTOP_CONFIG_FILE");
+  if (!config_path) {
+    const char *xdg_config_dir = getenv("XDG_CONFIG_HOME");
+    if (!xdg_config_dir)
+      xdg_config_dir = getenv("HOME");
+    if (xdg_config_dir) {
+      static char default_config_path[4096];
+      snprintf(default_config_path, sizeof(default_config_path), "%s/.config/nvtop/interface.ini", xdg_config_dir);
+      config_path = default_config_path;
+    }
+  }
+  if (config_path) {
+    FILE *f = fopen(config_path, "r");
+    if (f) {
+      ini_parse_file(f, remote_ini_handler, &ctx);
+      fclose(f);
+      /* Commit a trailing [RemoteHost] block at EOF */
+      remote_host_commit(&ctx);
+    }
+  }
+  /* Mirror TPU: return true if at least one host is configured, even if
+   * every host is currently unreachable. */
+  return remote_host_count > 0;
+}
+
+static void gpuinfo_remote_shutdown(void) {
+  struct remote_host *h, *h_safe;
+  list_for_each_entry_safe(h, h_safe, &remote_host_list, list) {
+    if (h->sock >= 0)
+      close(h->sock);
+    free(h->last_good);
+    free(h->last_good_static);
+    free(h->last_good_procs);
+    free(h);
+  }
+  INIT_LIST_HEAD(&remote_host_list);
+  free(remote_hosts);
+  remote_hosts = NULL;
+  remote_host_count = 0;
+}
+
+static const char *gpuinfo_remote_last_error_string(void) {
+  return "Remote GPU telemetry";
+}
+
+static bool gpuinfo_remote_get_device_handles(struct list_head *devices, unsigned *count) {
+  struct remote_host *h;
+  *count = 0;
+  list_for_each_entry(h, &remote_host_list, list) {
+    unsigned host_idx = *count;
+    /* Try an initial frame so we learn gpu_count + static info. */
+    if (h->sock < 0)
+      h->sock = remote_host_connect(h);
+    if (h->sock >= 0 && remote_host_refresh(h)) {
+      /* Allocate one gpu_info per remote GPU on this host. */
+      if (!h->gpus)
+        h->gpus = (struct gpu_info_remote *)calloc((size_t)h->gpu_count, sizeof(*h->gpus));
+      for (unsigned i = 0; i < h->gpu_count; ++i) {
+        struct gpu_info_remote *gpu = &h->gpus[i];
+        gpu->base.vendor = &gpu_vendor_remote;
+        gpu->host = h;
+        gpu->host_idx = host_idx;
+        gpu->gpu_idx = i;
+        snprintf(gpu->base.pdev, PDEV_LEN, "R%u_%u", host_idx, i);
+        gpu->base.processes_count = 0;
+        gpu->base.processes = NULL;
+        gpu->base.processes_array_size = 0;
+        list_add_tail(&gpu->base.list, devices);
+        *count += 1;
+      }
+    }
+  }
+  return remote_host_count > 0;
+}
+
+static void gpuinfo_remote_populate_static_info(struct gpu_info *_gpu_info) {
+  struct gpu_info_remote *gpu = container_of(_gpu_info, struct gpu_info_remote, base);
+  struct gpuinfo_static_info *static_info = &_gpu_info->static_info;
+  struct remote_host *h = gpu->host;
+  RESET_ALL(static_info->valid);
+
+  if (h->last_good_static && gpu->gpu_idx < h->gpu_count) {
+    struct wire_static *ws = h->last_good_static;
+    snprintf(static_info->device_name, sizeof(static_info->device_name), "%s GPU%u", h->name, gpu->gpu_idx);
+    SET_VALID(gpuinfo_device_name_valid, static_info->valid);
+    if (IS_VALID(gpuinfo_max_pcie_gen_valid, ws->valid))
+      SET_GPUINFO_STATIC(static_info, max_pcie_gen, ws->max_pcie_gen);
+    if (IS_VALID(gpuinfo_max_pcie_link_width_valid, ws->valid))
+      SET_GPUINFO_STATIC(static_info, max_pcie_link_width, ws->max_pcie_link_width);
+    if (IS_VALID(gpuinfo_temperature_shutdown_threshold_valid, ws->valid))
+      SET_GPUINFO_STATIC(static_info, temperature_shutdown_threshold, ws->temperature_shutdown_threshold);
+    if (IS_VALID(gpuinfo_temperature_slowdown_threshold_valid, ws->valid))
+      SET_GPUINFO_STATIC(static_info, temperature_slowdown_threshold, ws->temperature_slowdown_threshold);
+    if (IS_VALID(gpuinfo_n_shared_cores_valid, ws->valid))
+      SET_GPUINFO_STATIC(static_info, n_shared_cores, ws->n_shared_cores);
+    if (IS_VALID(gpuinfo_l2cache_size_valid, ws->valid))
+      SET_GPUINFO_STATIC(static_info, l2cache_size, ws->l2cache_size);
+    if (IS_VALID(gpuinfo_n_exec_engines_valid, ws->valid))
+      SET_GPUINFO_STATIC(static_info, n_exec_engines, ws->n_exec_engines);
+    if (IS_VALID(gpuinfo_engine_count_valid, ws->valid))
+      SET_GPUINFO_STATIC(static_info, engine_count, ws->engine_count);
+    static_info->integrated_graphics = ws->integrated_graphics;
+    static_info->encode_decode_shared = ws->encode_decode_shared;
+  } else {
+    snprintf(static_info->device_name, sizeof(static_info->device_name), "%s GPU%u", h->name, gpu->gpu_idx);
+    SET_VALID(gpuinfo_device_name_valid, static_info->valid);
+  }
+}
+
+static void gpuinfo_remote_refresh_dynamic_info(struct gpu_info *_gpu_info) {
+  struct gpu_info_remote *gpu = container_of(_gpu_info, struct gpu_info_remote, base);
+  struct gpuinfo_dynamic_info *dynamic_info = &_gpu_info->dynamic_info;
+  struct remote_host *h = gpu->host;
+
+  /* TPU-style 900 ms cache + last-good fallback: within the window reuse
+   * the cached frame; otherwise pull a fresh one. On failure keep the
+   * last-good data (stale) rather than blanking the panel. */
+  if (!remote_cache_valid(h))
+    remote_host_refresh(h);
+
+  if (!h->has_data || !h->last_good)
+    return;
+  if (gpu->gpu_idx >= h->gpu_count)
+    return;
+  struct wire_gpu *w = &h->last_good[gpu->gpu_idx];
+
+  RESET_ALL(dynamic_info->valid);
+  if (IS_VALID(gpuinfo_gpu_clock_speed_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, gpu_clock_speed, w->gpu_clock_speed);
+  if (IS_VALID(gpuinfo_gpu_clock_speed_max_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, gpu_clock_speed_max, w->gpu_clock_speed_max);
+  if (IS_VALID(gpuinfo_mem_clock_speed_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, mem_clock_speed, w->mem_clock_speed);
+  if (IS_VALID(gpuinfo_mem_clock_speed_max_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, mem_clock_speed_max, w->mem_clock_speed_max);
+  if (IS_VALID(gpuinfo_gpu_util_rate_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, gpu_util_rate, w->gpu_util_rate);
+  if (IS_VALID(gpuinfo_mem_util_rate_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, mem_util_rate, w->mem_util_rate);
+  if (IS_VALID(gpuinfo_encoder_rate_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, encoder_rate, w->encoder_rate);
+  if (IS_VALID(gpuinfo_decoder_rate_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, decoder_rate, w->decoder_rate);
+  if (IS_VALID(gpuinfo_total_memory_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, total_memory, (unsigned long long)w->total_memory);
+  if (IS_VALID(gpuinfo_free_memory_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, free_memory, (unsigned long long)w->free_memory);
+  if (IS_VALID(gpuinfo_used_memory_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, used_memory, (unsigned long long)w->used_memory);
+  if (IS_VALID(gpuinfo_pcie_link_gen_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, pcie_link_gen, w->pcie_link_gen);
+  if (IS_VALID(gpuinfo_pcie_link_width_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, pcie_link_width, w->pcie_link_width);
+  if (IS_VALID(gpuinfo_pcie_rx_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, pcie_rx, w->pcie_rx);
+  if (IS_VALID(gpuinfo_pcie_tx_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, pcie_tx, w->pcie_tx);
+  if (IS_VALID(gpuinfo_fan_speed_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, fan_speed, w->fan_speed);
+  if (IS_VALID(gpuinfo_fan_rpm_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, fan_rpm, w->fan_rpm);
+  if (IS_VALID(gpuinfo_gpu_temp_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, gpu_temp, w->gpu_temp);
+  if (IS_VALID(gpuinfo_power_draw_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, power_draw, w->power_draw);
+  if (IS_VALID(gpuinfo_power_draw_max_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, power_draw_max, w->power_draw_max);
+  if (IS_VALID(gpuinfo_multi_instance_mode_valid, w->valid))
+    SET_GPUINFO_DYNAMIC(dynamic_info, multi_instance_mode, w->multi_instance_mode);
+}
+
+static void gpuinfo_remote_refresh_running_processes(struct gpu_info *_gpu_info) {
+  struct gpu_info_remote *gpu = container_of(_gpu_info, struct gpu_info_remote, base);
+  struct remote_host *h = gpu->host;
+  if (!h->has_data || !h->last_good)
+    return;
+  if (gpu->gpu_idx >= h->gpu_count)
+    return;
+  struct wire_gpu *w = &h->last_good[gpu->gpu_idx];
+  if (w->process_count == 0) {
+    _gpu_info->processes_count = 0;
+    return;
+  }
+  _gpu_info->processes_count = w->process_count;
+  if (_gpu_info->processes_array_size < w->process_count) {
+    _gpu_info->processes_array_size = w->process_count;
+    _gpu_info->processes = (struct gpu_process *)malloc(_gpu_info->processes_array_size * sizeof(*_gpu_info->processes));
+    memset(_gpu_info->processes, 0, _gpu_info->processes_array_size * sizeof(*_gpu_info->processes));
+  }
+  for (unsigned i = 0; i < w->process_count; ++i) {
+    struct wire_process *wp = &h->last_good_procs[i];
+    struct gpu_process *p = &_gpu_info->processes[i];
+    p->type = (enum gpu_process_type)wp->type;
+    p->pid = (pid_t)wp->pid;
+    if (_gpu_info->processes[i].cmdline)
+      free(_gpu_info->processes[i].cmdline);
+    _gpu_info->processes[i].cmdline = strdup(wp->cmdline[0] ? wp->cmdline : "N/A");
+    if (IS_VALID(gpuinfo_process_cmdline_valid, wp->valid))
+      SET_VALID(gpuinfo_process_cmdline_valid, p->valid);
+    if (wp->user_name[0]) {
+      free(p->user_name);
+      p->user_name = strdup(wp->user_name);
+      SET_VALID(gpuinfo_process_user_name_valid, p->valid);
+    }
+    p->sample_delta = wp->sample_delta;
+    p->gfx_engine_used = wp->gfx_engine_used;
+    p->compute_engine_used = wp->compute_engine_used;
+    p->enc_engine_used = wp->enc_engine_used;
+    p->dec_engine_used = wp->dec_engine_used;
+    p->gpu_cycles = wp->gpu_cycles;
+    if (IS_VALID(gpuinfo_process_gpu_usage_valid, wp->valid)) {
+      p->gpu_usage = wp->gpu_usage;
+      SET_VALID(gpuinfo_process_gpu_usage_valid, p->valid);
+    }
+    if (IS_VALID(gpuinfo_process_encode_usage_valid, wp->valid)) {
+      p->encode_usage = wp->encode_usage;
+      SET_VALID(gpuinfo_process_encode_usage_valid, p->valid);
+    }
+    if (IS_VALID(gpuinfo_process_decode_usage_valid, wp->valid)) {
+      p->decode_usage = wp->decode_usage;
+      SET_VALID(gpuinfo_process_decode_usage_valid, p->valid);
+    }
+    if (IS_VALID(gpuinfo_process_gpu_memory_usage_valid, wp->valid)) {
+      p->gpu_memory_usage = (unsigned long long)wp->gpu_memory_usage;
+      SET_VALID(gpuinfo_process_gpu_memory_usage_valid, p->valid);
+    }
+    if (IS_VALID(gpuinfo_process_gpu_memory_percentage_valid, wp->valid)) {
+      p->gpu_memory_percentage = wp->gpu_memory_percentage;
+      SET_VALID(gpuinfo_process_gpu_memory_percentage_valid, p->valid);
+    }
+    if (IS_VALID(gpuinfo_process_cpu_usage_valid, wp->valid)) {
+      p->cpu_usage = wp->cpu_usage;
+      SET_VALID(gpuinfo_process_cpu_usage_valid, p->valid);
+    }
+  }
+}

--- a/src/nvtop.c
+++ b/src/nvtop.c
@@ -26,6 +26,10 @@
 #include "nvtop/interface_options.h"
 #include "nvtop/time.h"
 #include "nvtop/version.h"
+#if REMOTE_SUPPORT
+#include "nvtop/export_server.h"
+#include "nvtop/remote_proto.h"
+#endif
 
 #include <getopt.h>
 #include <ncurses.h>
@@ -76,7 +80,12 @@ static const char helpstring[] = "Available options:\n"
                                  "  -h --help         : Print help and exit\n"
                                  "  -s --snapshot     : Output the current gpu stats without ncurses"
                                  "(useful for scripting)\n"
-                                 "  -l --loop         : Output the current gpu stats without ncurses in a loop\n";
+                                 "  -l --loop         : Output the current gpu stats without ncurses in a loop\n"
+#if REMOTE_SUPPORT
+                                 "  -x --export       : Serve gpu stats to remote consumers over TCP "
+                                 "(optionally --export <port>, --bind <addr>)\n"
+#endif
+;
 
 static const char versionString[] = "nvtop version " NVTOP_VERSION_STRING;
 
@@ -95,10 +104,18 @@ static const struct option long_opts[] = {
     {.name = "reverse-abs", .has_arg = no_argument, .flag = NULL, .val = 'r'},
     {.name = "snapshot", .has_arg = no_argument, .flag = NULL, .val = 's'},
     {.name = "loop", .has_arg = no_argument, .flag = NULL, .val = 'l'},
+#if REMOTE_SUPPORT
+    {.name = "export", .has_arg = optional_argument, .flag = NULL, .val = 'x'},
+    {.name = "bind", .has_arg = required_argument, .flag = NULL, .val = 'b'},
+#endif
     {0, 0, 0, 0},
 };
 
-static const char opts[] = "hvd:c:CfE:pPrisl";
+static const char opts[] = "hvd:c:CfE:pPrisl"
+#if REMOTE_SUPPORT
+                            "xb:"
+#endif
+                            ;
 
 int main(int argc, char **argv) {
   (void)setlocale(LC_CTYPE, "");
@@ -117,6 +134,12 @@ int main(int argc, char **argv) {
   bool loop_snapshot = false;
   double encode_decode_hide_time = -1.;
   char *custom_config_file_path = NULL;
+#if REMOTE_SUPPORT
+  bool export_enabled = false;
+  unsigned short export_port = NVTOP_EXPORT_DEFAULT_PORT;
+  char *export_bind = "0.0.0.0";
+  int export_port_argc = 0;
+#endif
   while (true) {
     int optchar = getopt_long(argc, argv, opts, long_opts, NULL);
     if (optchar == -1)
@@ -181,6 +204,23 @@ int main(int argc, char **argv) {
     case 'l':
       loop_snapshot = true;
       break;
+#if REMOTE_SUPPORT
+    case 'x':
+      export_enabled = true;
+      if (optarg) {
+        char *endptr = NULL;
+        long p = strtol(optarg, &endptr, 0);
+        if (endptr == optarg || p < 1 || p > 65535) {
+          fprintf(stderr, "Error: invalid port for --export\n");
+          exit(EXIT_FAILURE);
+        }
+        export_port = (unsigned short)p;
+      }
+      break;
+    case 'b':
+      export_bind = optarg;
+      break;
+#endif
     case ':':
     case '?':
       switch (optopt) {
@@ -226,12 +266,58 @@ int main(int argc, char **argv) {
   unsigned allDevCount = 0;
   LIST_HEAD(monitoredGpus);
   LIST_HEAD(nonMonitoredGpus);
+
+#if REMOTE_SUPPORT
+  /* Start the export server BEFORE init so a remote vendor that dials this
+   * exporter's own port (the self-connect case) finds it listening. The
+   * poll/encode only happens in the loop, so the GPU list need not be
+   * populated yet. */
+  if (export_enabled) {
+    export_server_init(&monitoredGpus);
+    if (export_server_start(export_port, export_bind) != 0) {
+      fprintf(stderr, "Error: could not bind the export server on port %u\n", export_port);
+      return EXIT_FAILURE;
+    }
+  }
+#endif
+
   if (!gpuinfo_init_info_extraction(&allDevCount, &monitoredGpus))
     return EXIT_FAILURE;
   if (allDevCount == 0) {
     fprintf(stdout, "No GPU to monitor.\n");
+    if (export_enabled)
+      export_server_stop();
     return EXIT_SUCCESS;
   }
+
+#if REMOTE_SUPPORT
+  if (export_enabled) {
+    gpuinfo_populate_static_infos(&monitoredGpus);
+    // Same refresh cadence as the snapshot loop; the server only serializes
+    // the already-populated structs when a consumer polls.
+    if (!update_interval_option_set)
+      update_interval_option = 100;
+    while (!signal_exit) {
+      export_server_poll();
+      #if _POSIX_C_SOURCE >= 199309L
+      struct timespec tv = {.tv_sec = update_interval_option / 1000,
+                            .tv_nsec = (update_interval_option % 1000) * 1000000};
+      nanosleep(&tv, &tv);
+      #else
+      sleep(update_interval_option / 1000 > 0 ? update_interval_option / 1000 : 1);
+      #endif
+      if (signal_exit)
+        break;
+      gpuinfo_refresh_dynamic_info(&monitoredGpus);
+      gpuinfo_refresh_processes(&monitoredGpus);
+      gpuinfo_utilisation_rate(&monitoredGpus);
+      gpuinfo_fix_dynamic_info_from_process_info(&monitoredGpus);
+    }
+    export_server_stop();
+    gpuinfo_shutdown_info_extraction(&monitoredGpus);
+    return EXIT_SUCCESS;
+  }
+#endif
 
   if (show_snapshot || loop_snapshot) {
     gpuinfo_populate_static_infos(&monitoredGpus);
@@ -342,6 +428,10 @@ int main(int argc, char **argv) {
         gpuinfo_utilisation_rate(&monitoredGpus);
         gpuinfo_fix_dynamic_info_from_process_info(&monitoredGpus);
       }
+#if REMOTE_SUPPORT
+      if (export_enabled)
+        export_server_poll();
+#endif
       save_current_data_to_ring(&monitoredGpus, interface);
       timeout(interface_update_interval(interface));
       time_slept = 0.;
@@ -418,6 +508,10 @@ int main(int argc, char **argv) {
   }
 
   clean_ncurses(interface);
+#if REMOTE_SUPPORT
+  if (export_enabled)
+    export_server_stop();
+#endif
   gpuinfo_shutdown_info_extraction(&monitoredGpus);
 
   return EXIT_SUCCESS;

--- a/src/remote_wire.c
+++ b/src/remote_wire.c
@@ -1,0 +1,434 @@
+/*
+ *
+ * Copyright (C) 2026 Nvtop contributors
+ *
+ * This file is part of Nvtop.
+ *
+ * Nvtop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nvtop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with nvtop.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "nvtop/remote_proto.h"
+
+#include <stdlib.h>
+#include <string.h>
+
+/*
+ * Wire codec for the NVT1 remote telemetry protocol.
+ *
+ * The encode side walks the live `gpu_info` device list and serializes
+ * each device into a fixed-layout wire struct with explicit little-endian
+ * integers. The `valid[]` bitmaps are forwarded verbatim so the consumer
+ * can mark absent fields N/A without extra logic.
+ */
+
+/* Fixed sizes (must match the structs) ------------------------------------ */
+
+#define WIRE_HEADER_LEN sizeof(struct wire_header)
+#define WIRE_STATIC_LEN (MAX_DEVICE_NAME + 8 * 4 + 2 + ((gpuinfo_static_info_count + CHAR_BIT - 1) / CHAR_BIT))
+/* Byte offset to the gpu block's process_count field (not including it);
+ * process records begin 4 bytes after this offset. */
+#define WIRE_GPU_FIXED_LEN (18 * 4 + 3 * 8 + 1 + ((gpuinfo_dynamic_info_count + CHAR_BIT - 1) / CHAR_BIT))
+#define WIRE_PROCESS_LEN sizeof(struct wire_process)
+#define WIRE_STATIC_COUNT 1
+#define WIRE_MAX_GPUS 16
+#define WIRE_MAX_PROCS 64
+
+/* LE encode/decode helpers --------------------------------------------------- */
+
+static inline void le_put32(uint8_t *p, uint32_t v) {
+  p[0] = (uint8_t)v;
+  p[1] = (uint8_t)(v >> 8);
+  p[2] = (uint8_t)(v >> 16);
+  p[3] = (uint8_t)(v >> 24);
+}
+
+static inline void le_put64(uint8_t *p, uint64_t v) {
+  le_put32(p, (uint32_t)v);
+  le_put32(p + 4, (uint32_t)(v >> 32));
+}
+
+static inline uint32_t le_get32(const uint8_t *p) {
+  return (uint32_t)p[0] | ((uint32_t)p[1] << 8) | ((uint32_t)p[2] << 16) | ((uint32_t)p[3] << 24);
+}
+
+static inline uint64_t le_get64(const uint8_t *p) {
+  return ((uint64_t)le_get32(p + 4) << 32) | le_get32(p);
+}
+
+static size_t encode_wire_static(uint8_t *dst, const struct gpuinfo_static_info *s) {
+  size_t off = 0;
+  memcpy(dst + off, s->device_name, MAX_DEVICE_NAME);
+  off += MAX_DEVICE_NAME;
+  le_put32(dst + off, s->max_pcie_gen);
+  off += 4;
+  le_put32(dst + off, s->max_pcie_link_width);
+  off += 4;
+  le_put32(dst + off, s->temperature_shutdown_threshold);
+  off += 4;
+  le_put32(dst + off, s->temperature_slowdown_threshold);
+  off += 4;
+  le_put32(dst + off, s->n_shared_cores);
+  off += 4;
+  le_put32(dst + off, s->l2cache_size);
+  off += 4;
+  le_put32(dst + off, s->n_exec_engines);
+  off += 4;
+  le_put32(dst + off, s->engine_count);
+  off += 4;
+  dst[off] = s->integrated_graphics ? 1 : 0;
+  dst[off + 1] = s->encode_decode_shared ? 1 : 0;
+  off += 2;
+  memcpy(dst + off, s->valid, sizeof(s->valid));
+  return WIRE_STATIC_LEN;
+}
+
+static size_t encode_wire_process(uint8_t *dst, const struct gpu_process *p) {
+  size_t off = 0;
+  le_put32(dst + off, p->type);
+  off += 4;
+  le_put32(dst + off, (uint32_t)p->pid);
+  off += 4;
+  if (p->cmdline) {
+    size_t n = strlen(p->cmdline);
+    if (n >= REMOTE_CMDLINE_LEN) n = REMOTE_CMDLINE_LEN - 1;
+    memcpy(dst + off, p->cmdline, n);
+  } else {
+    dst[off] = 0;
+  }
+  off += REMOTE_CMDLINE_LEN;
+  if (p->user_name) {
+    size_t n = strlen(p->user_name);
+    if (n >= REMOTE_NAME_LEN) n = REMOTE_NAME_LEN - 1;
+    memcpy(dst + off, p->user_name, n);
+  } else {
+    dst[off] = 0;
+  }
+  off += REMOTE_NAME_LEN;
+  le_put64(dst + off, p->sample_delta);
+  off += 8;
+  le_put64(dst + off, p->gfx_engine_used);
+  off += 8;
+  le_put64(dst + off, p->compute_engine_used);
+  off += 8;
+  le_put64(dst + off, p->enc_engine_used);
+  off += 8;
+  le_put64(dst + off, p->dec_engine_used);
+  off += 8;
+  le_put64(dst + off, p->gpu_cycles);
+  off += 8;
+  le_put32(dst + off, p->gpu_usage);
+  off += 4;
+  le_put32(dst + off, p->encode_usage);
+  off += 4;
+  le_put32(dst + off, p->decode_usage);
+  off += 4;
+  le_put64(dst + off, p->gpu_memory_usage);
+  off += 8;
+  le_put32(dst + off, p->gpu_memory_percentage);
+  off += 4;
+  le_put32(dst + off, p->cpu_usage);
+  off += 4;
+  le_put64(dst + off, p->cpu_memory_virt);
+  off += 8;
+  le_put64(dst + off, p->cpu_memory_res);
+  off += 8;
+  memcpy(dst + off, p->valid, sizeof(p->valid));
+  return WIRE_PROCESS_LEN;
+}
+
+static size_t encode_wire_gpu(uint8_t *dst, const struct gpu_info *device) {
+  const struct gpuinfo_dynamic_info *d = &device->dynamic_info;
+  size_t off = 0;
+  le_put32(dst + off, d->gpu_clock_speed);
+  off += 4;
+  le_put32(dst + off, d->gpu_clock_speed_max);
+  off += 4;
+  le_put32(dst + off, d->mem_clock_speed);
+  off += 4;
+  le_put32(dst + off, d->mem_clock_speed_max);
+  off += 4;
+  le_put32(dst + off, d->gpu_util_rate);
+  off += 4;
+  le_put32(dst + off, d->mem_util_rate);
+  off += 4;
+  le_put32(dst + off, d->effective_load_rate);
+  off += 4;
+  le_put32(dst + off, d->encoder_rate);
+  off += 4;
+  le_put32(dst + off, d->decoder_rate);
+  off += 4;
+  le_put64(dst + off, d->total_memory);
+  off += 8;
+  le_put64(dst + off, d->free_memory);
+  off += 8;
+  le_put64(dst + off, d->used_memory);
+  off += 8;
+  le_put32(dst + off, d->pcie_link_gen);
+  off += 4;
+  le_put32(dst + off, d->pcie_link_width);
+  off += 4;
+  le_put32(dst + off, d->pcie_rx);
+  off += 4;
+  le_put32(dst + off, d->pcie_tx);
+  off += 4;
+  le_put32(dst + off, d->fan_speed);
+  off += 4;
+  le_put32(dst + off, d->fan_rpm);
+  off += 4;
+  le_put32(dst + off, d->gpu_temp);
+  off += 4;
+  le_put32(dst + off, d->power_draw);
+  off += 4;
+  le_put32(dst + off, d->power_draw_max);
+  off += 4;
+  dst[off] = d->multi_instance_mode ? 1 : 0;
+  off += 1;
+  memcpy(dst + off, d->valid, sizeof(d->valid));
+  off += sizeof(d->valid);
+  unsigned pc = device->processes_count;
+  if (pc > WIRE_MAX_PROCS) pc = WIRE_MAX_PROCS;
+  le_put32(dst + off, pc);
+  off += 4;
+  for (unsigned i = 0; i < pc; ++i) {
+    encode_wire_process(dst + off, &device->processes[i]);
+    off += WIRE_PROCESS_LEN;
+  }
+  return off;
+}
+
+/* Public encode: walk the device list, serialize, return total frame length */
+
+size_t remote_wire_encode(struct list_head *monitored_gpus, uint8_t *out, size_t out_size) {
+  struct gpu_info *device;
+  unsigned gpu_count = 0;
+  list_for_each_entry(device, monitored_gpus, list) {
+    if (gpu_count < WIRE_MAX_GPUS) gpu_count++;
+  }
+
+  struct wire_header header;
+  memset(&header, 0, sizeof(header));
+  memcpy(header.magic, NVTOP_EXPORT_MAGIC, 4);
+  header.proto_major = remote_proto_major;
+  header.proto_minor = remote_proto_minor;
+  header.flags = 1; /* payload integers are little-endian */
+  header.static_count = WIRE_STATIC_COUNT;
+  header.gpu_count = gpu_count;
+
+  size_t static_len = WIRE_STATIC_COUNT * WIRE_STATIC_LEN;
+  // Actual total = header + statics + per-gpu (fixed part + process_count + processes)
+  size_t actual_total = WIRE_HEADER_LEN + static_len;
+  {
+    list_for_each_entry(device, monitored_gpus, list) {
+      unsigned pc = device->processes_count;
+      if (pc > WIRE_MAX_PROCS) pc = WIRE_MAX_PROCS;
+      /* WIRE_GPU_FIXED_LEN points at the process_count field; add 4 for it,
+       * then the process records. */
+      actual_total += WIRE_GPU_FIXED_LEN + 4 + (size_t)pc * WIRE_PROCESS_LEN;
+    }
+  }
+
+  // `out` must hold the 4-byte prefix + payload. Reserve `actual_total + 4`.
+  if (actual_total + 4 > out_size) return 0;
+
+  uint8_t *dst = out + 4;
+  memcpy(dst, &header, WIRE_HEADER_LEN);
+  dst += WIRE_HEADER_LEN;
+
+  // static block: use the first monitored GPU's static info
+  struct gpu_info *first = NULL;
+  list_for_each_entry(device, monitored_gpus, list) {
+    if (!first) first = device;
+  }
+  if (first) {
+    encode_wire_static(dst, &first->static_info);
+    dst += WIRE_STATIC_LEN;
+  }
+
+  list_for_each_entry(device, monitored_gpus, list) {
+    size_t len = encode_wire_gpu(dst, device);
+    dst += len;
+  }
+
+  // The payload length is exactly the number of bytes actually written.
+  size_t payload_len = (size_t)(dst - (out + 4));
+
+  // 4-byte big-endian length prefix = payload length (bytes AFTER the prefix).
+  uint32_t total32 = (uint32_t)payload_len;
+  out[0] = (uint8_t)(total32 >> 24);
+  out[1] = (uint8_t)(total32 >> 16);
+  out[2] = (uint8_t)(total32 >> 8);
+  out[3] = (uint8_t)total32;
+
+  return payload_len;
+}
+
+/* Public decode: parse a frame (4-byte big-endian length + payload) */
+
+unsigned remote_wire_decode(const uint8_t *frame, size_t frame_size, struct wire_static *statics,
+                            struct wire_gpu *gpus, struct wire_process *procs) {
+  // Minimum valid frame: 4-byte length prefix + header + at least one static block
+  size_t min_size = 4 + WIRE_HEADER_LEN + WIRE_STATIC_LEN;
+  if (frame_size < min_size) return 0;
+
+  uint32_t declared = ((uint32_t)frame[0] << 24) | ((uint32_t)frame[1] << 16) | ((uint32_t)frame[2] << 8) | (uint32_t)frame[3];
+  if ((size_t)declared + 4 > frame_size) return 0;
+
+  const uint8_t *dst = frame + 4;
+  struct wire_header header;
+  memcpy(&header, dst, sizeof(header));
+  if (memcmp(header.magic, NVTOP_EXPORT_MAGIC, 4) != 0) return 0;
+  if (header.proto_major > remote_proto_major) return 0;
+  if (header.static_count > WIRE_STATIC_COUNT || header.gpu_count > WIRE_MAX_GPUS) return 0;
+
+  dst += sizeof(header);
+  for (size_t i = 0; i < header.static_count; ++i) {
+    if (statics) {
+      struct wire_static *s = &statics[i];
+      size_t off = 0;
+      memcpy(s->device_name, dst + off, MAX_DEVICE_NAME);
+      off += MAX_DEVICE_NAME;
+      s->max_pcie_gen = le_get32(dst + off);
+      off += 4;
+      s->max_pcie_link_width = le_get32(dst + off);
+      off += 4;
+      s->temperature_shutdown_threshold = le_get32(dst + off);
+      off += 4;
+      s->temperature_slowdown_threshold = le_get32(dst + off);
+      off += 4;
+      s->n_shared_cores = le_get32(dst + off);
+      off += 4;
+      s->l2cache_size = le_get32(dst + off);
+      off += 4;
+      s->n_exec_engines = le_get32(dst + off);
+      off += 4;
+      s->engine_count = le_get32(dst + off);
+      off += 4;
+      s->integrated_graphics = dst[off];
+      s->encode_decode_shared = dst[off + 1];
+      off += 2;
+      memcpy(s->valid, dst + off, sizeof(s->valid));
+      dst += WIRE_STATIC_LEN;
+    } else {
+      dst += WIRE_STATIC_LEN;
+    }
+  }
+
+  for (size_t i = 0; i < header.gpu_count; ++i) {
+    size_t off = 0;
+    if (gpus) {
+      struct wire_gpu *g = &gpus[i];
+      g->gpu_clock_speed = le_get32(dst + off);
+      off += 4;
+      g->gpu_clock_speed_max = le_get32(dst + off);
+      off += 4;
+      g->mem_clock_speed = le_get32(dst + off);
+      off += 4;
+      g->mem_clock_speed_max = le_get32(dst + off);
+      off += 4;
+      g->gpu_util_rate = le_get32(dst + off);
+      off += 4;
+      g->mem_util_rate = le_get32(dst + off);
+      off += 4;
+      g->effective_load_rate = le_get32(dst + off);
+      off += 4;
+      g->encoder_rate = le_get32(dst + off);
+      off += 4;
+      g->decoder_rate = le_get32(dst + off);
+      off += 4;
+      g->total_memory = le_get64(dst + off);
+      off += 8;
+      g->free_memory = le_get64(dst + off);
+      off += 8;
+      g->used_memory = le_get64(dst + off);
+      off += 8;
+      g->pcie_link_gen = le_get32(dst + off);
+      off += 4;
+      g->pcie_link_width = le_get32(dst + off);
+      off += 4;
+      g->pcie_rx = le_get32(dst + off);
+      off += 4;
+      g->pcie_tx = le_get32(dst + off);
+      off += 4;
+      g->fan_speed = le_get32(dst + off);
+      off += 4;
+      g->fan_rpm = le_get32(dst + off);
+      off += 4;
+      g->gpu_temp = le_get32(dst + off);
+      off += 4;
+      g->power_draw = le_get32(dst + off);
+      off += 4;
+      g->power_draw_max = le_get32(dst + off);
+      off += 4;
+      g->multi_instance_mode = dst[off];
+      off += 1;
+      memcpy(g->valid, dst + off, sizeof(g->valid));
+      off += sizeof(g->valid);
+      g->process_count = le_get32(dst + off);
+      off += 4;
+      if (g->process_count > WIRE_MAX_PROCS) g->process_count = WIRE_MAX_PROCS;
+      for (unsigned j = 0; j < g->process_count; ++j) {
+        if (procs) {
+          struct wire_process *w = &procs[j];
+          size_t poff = 0;
+          w->type = le_get32(dst + poff);
+          poff += 4;
+          w->pid = le_get32(dst + poff);
+          poff += 4;
+          memcpy(w->cmdline, dst + poff, REMOTE_CMDLINE_LEN);
+          poff += REMOTE_CMDLINE_LEN;
+          memcpy(w->user_name, dst + poff, REMOTE_NAME_LEN);
+          poff += REMOTE_NAME_LEN;
+          w->sample_delta = le_get64(dst + poff);
+          poff += 8;
+          w->gfx_engine_used = le_get64(dst + poff);
+          poff += 8;
+          w->compute_engine_used = le_get64(dst + poff);
+          poff += 8;
+          w->enc_engine_used = le_get64(dst + poff);
+          poff += 8;
+          w->dec_engine_used = le_get64(dst + poff);
+          poff += 8;
+          w->gpu_cycles = le_get64(dst + poff);
+          poff += 8;
+          w->gpu_usage = le_get32(dst + poff);
+          poff += 4;
+          w->encode_usage = le_get32(dst + poff);
+          poff += 4;
+          w->decode_usage = le_get32(dst + poff);
+          poff += 4;
+          w->gpu_memory_usage = le_get64(dst + poff);
+          poff += 8;
+          w->gpu_memory_percentage = le_get32(dst + poff);
+          poff += 4;
+          w->cpu_usage = le_get32(dst + poff);
+          poff += 4;
+          w->cpu_memory_virt = le_get64(dst + poff);
+          poff += 8;
+          w->cpu_memory_res = le_get64(dst + poff);
+          poff += 8;
+          memcpy(w->valid, dst + poff, sizeof(w->valid));
+        }
+        dst += WIRE_PROCESS_LEN;
+      }
+      dst += WIRE_GPU_FIXED_LEN;
+    } else {
+      // skip this gpu block: fixed part + process_count + process records
+      unsigned pc = le_get32(dst + WIRE_GPU_FIXED_LEN);
+      if (pc > WIRE_MAX_PROCS) pc = WIRE_MAX_PROCS;
+      dst += WIRE_GPU_FIXED_LEN + (size_t)pc * WIRE_PROCESS_LEN;
+    }
+  }
+
+  return (unsigned)header.gpu_count;
+}

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -9,7 +9,15 @@ if (BUILD_TESTING AND GTest_FOUND)
     ${PROJECT_SOURCE_DIR}/src/extract_processinfo_fdinfo.c
     ${PROJECT_SOURCE_DIR}/src/interface_options.c
     ${PROJECT_SOURCE_DIR}/src/ini.c
+    ${PROJECT_SOURCE_DIR}/src/time.c
   )
+  if (REMOTE_SUPPORT)
+    target_sources(testLib PRIVATE
+      ${PROJECT_SOURCE_DIR}/src/remote_wire.c
+      ${PROJECT_SOURCE_DIR}/src/extract_gpuinfo_remote.c
+      ${PROJECT_SOURCE_DIR}/src/export_server.c)
+    target_compile_definitions(testLib PRIVATE REMOTE_SUPPORT=1)
+  endif()
   target_include_directories(testLib PUBLIC
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_BINARY_DIR}/include)
@@ -21,6 +29,15 @@ if (BUILD_TESTING AND GTest_FOUND)
   )
   target_link_libraries(interfaceTests PRIVATE testLib GTest::gtest_main)
   gtest_discover_tests(interfaceTests)
+
+  if (REMOTE_SUPPORT)
+    add_executable(
+      wireTests
+      wireTest.cpp
+    )
+    target_link_libraries(wireTests PRIVATE testLib GTest::gtest_main)
+    gtest_discover_tests(wireTests)
+  endif()
 
   if (THOROUGH_TESTING)
     target_compile_definitions(interfaceTests PRIVATE THOROUGH_TESTING)

--- a/tests/wireTest.cpp
+++ b/tests/wireTest.cpp
@@ -1,0 +1,151 @@
+/*
+ *
+ * Copyright (C) 2026 Nvtop contributors
+ *
+ * This file is part of Nvtop.
+ *
+ * Nvtop is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * Nvtop is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with nvtop.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <gtest/gtest.h>
+
+extern "C" {
+#include "list.h"
+#include "nvtop/extract_gpuinfo_common.h"
+#include "nvtop/remote_proto.h"
+}
+
+namespace {
+
+LIST_HEAD(devices);
+
+struct gpu_info *make_device(const char *pdev, struct gpu_process *procs, unsigned proc_count) {
+  struct gpu_info *d = (struct gpu_info *)calloc(1, sizeof(*d));
+  snprintf(d->pdev, PDEV_LEN, "%s", pdev);
+  d->processes = procs;
+  d->processes_count = proc_count;
+  d->processes_array_size = proc_count;
+  list_add_tail(&d->list, &devices);
+  return d;
+}
+
+TEST(RemoteWire, RoundTrip) {
+  // Build a fake device list with known values.
+  INIT_LIST_HEAD(&devices);
+
+  struct gpu_process procs[2];
+  memset(procs, 0, sizeof(procs));
+  procs[0].type = gpu_process_compute;
+  procs[0].pid = 1234;
+  procs[0].gpu_usage = 42;
+  procs[0].gpu_memory_usage = 1024;
+  procs[0].cmdline = (char *)"vllm serve";
+  procs[0].user_name = (char *)"gpu_user";
+  SET_VALID(gpuinfo_process_cmdline_valid, procs[0].valid);
+  SET_VALID(gpuinfo_process_user_name_valid, procs[0].valid);
+  SET_VALID(gpuinfo_process_gpu_usage_valid, procs[0].valid);
+  SET_VALID(gpuinfo_process_gpu_memory_usage_valid, procs[0].valid);
+
+  struct gpu_info *d0 = make_device("card0", procs, 2);
+  struct gpu_info *d1 = make_device("card1", NULL, 0);
+
+  struct gpuinfo_dynamic_info *dyn0 = &d0->dynamic_info;
+  RESET_ALL(dyn0->valid);
+  SET_GPUINFO_DYNAMIC(dyn0, gpu_clock_speed, 1500);
+  SET_GPUINFO_DYNAMIC(dyn0, gpu_clock_speed_max, 2100);
+  SET_GPUINFO_DYNAMIC(dyn0, gpu_util_rate, 87);
+  SET_GPUINFO_DYNAMIC(dyn0, total_memory, 24ULL * 1024 * 1024 * 1024);
+  SET_GPUINFO_DYNAMIC(dyn0, used_memory, 8ULL * 1024 * 1024 * 1024);
+  SET_GPUINFO_DYNAMIC(dyn0, gpu_temp, 65);
+  SET_GPUINFO_DYNAMIC(dyn0, power_draw, 25000);
+
+  struct gpuinfo_static_info *st0 = &d0->static_info;
+  RESET_ALL(st0->valid);
+  snprintf(st0->device_name, sizeof(st0->device_name), "RTX 3090");
+  SET_VALID(gpuinfo_device_name_valid, st0->valid);
+  SET_GPUINFO_STATIC(st0, max_pcie_gen, 4);
+  SET_GPUINFO_STATIC(st0, max_pcie_link_width, 16);
+
+  struct gpuinfo_dynamic_info *dyn1 = &d1->dynamic_info;
+  RESET_ALL(dyn1->valid);
+  SET_GPUINFO_DYNAMIC(dyn1, gpu_util_rate, 12);
+  SET_GPUINFO_DYNAMIC(dyn1, total_memory, 122ULL * 1024 * 1024 * 1024);
+
+  // Encode
+  uint8_t buf[1 << 16];
+  size_t total = remote_wire_encode(&devices, buf, sizeof(buf));
+  ASSERT_GT(total, 0u);
+  ASSERT_LE(total, sizeof(buf));
+
+  // Decode
+  struct wire_static statics[1] = {{0}};
+  struct wire_gpu gpus[2] = {{0}};
+  struct wire_process procs_out[64] = {{0}};
+  unsigned n = remote_wire_decode(buf, total, statics, gpus, procs_out);
+
+  EXPECT_EQ(n, 2u);
+
+  // Header checks
+  EXPECT_EQ(gpus[0].gpu_clock_speed, 1500u);
+  EXPECT_EQ(gpus[0].gpu_clock_speed_max, 2100u);
+  EXPECT_EQ(gpus[0].gpu_util_rate, 87u);
+  EXPECT_EQ(gpus[0].total_memory, 24ULL * 1024 * 1024 * 1024);
+  EXPECT_EQ(gpus[0].used_memory, 8ULL * 1024 * 1024 * 1024);
+  EXPECT_EQ(gpus[0].gpu_temp, 65u);
+  EXPECT_EQ(gpus[0].power_draw, 25000u);
+  EXPECT_EQ(gpus[0].process_count, 2u);
+  EXPECT_STREQ(procs_out[0].cmdline, "vllm serve");
+  EXPECT_STREQ(procs_out[0].user_name, "gpu_user");
+  EXPECT_EQ(procs_out[0].gpu_usage, 42u);
+  EXPECT_EQ(gpus[1].gpu_util_rate, 12u);
+  EXPECT_EQ(gpus[1].total_memory, 122ULL * 1024 * 1024 * 1024);
+
+  // valid[] bits forwarded verbatim
+  EXPECT_TRUE(IS_VALID(gpuinfo_gpu_util_rate_valid, gpus[0].valid));
+  EXPECT_TRUE(IS_VALID(gpuinfo_gpu_clock_speed_valid, gpus[0].valid));
+  EXPECT_TRUE(IS_VALID(gpuinfo_gpu_temp_valid, gpus[0].valid));
+  EXPECT_TRUE(IS_VALID(gpuinfo_process_cmdline_valid, procs_out[0].valid));
+
+  // Static block round-trips the device name.
+  EXPECT_STREQ(statics[0].device_name, "RTX 3090");
+  EXPECT_EQ(statics[0].max_pcie_gen, 4u);
+  EXPECT_EQ(statics[0].max_pcie_link_width, 16u);
+  EXPECT_TRUE(IS_VALID(gpuinfo_max_pcie_gen_valid, statics[0].valid));
+}
+
+TEST(RemoteWire, TruncatedBufferReturnsError) {
+  INIT_LIST_HEAD(&devices);
+  struct gpu_info *d0 = make_device("card0", NULL, 0);
+  struct gpuinfo_dynamic_info *dyn = &d0->dynamic_info;
+  RESET_ALL(dyn->valid);
+  SET_GPUINFO_DYNAMIC(dyn, gpu_util_rate, 55);
+
+  uint8_t buf[1 << 16];
+  size_t total = remote_wire_encode(&devices, buf, sizeof(buf));
+  ASSERT_GT(total, 0u);
+
+  // Feeding a frame smaller than the declared length must fail.
+  struct wire_static s[1] = {{0}};
+  struct wire_gpu g[2] = {{0}};
+  struct wire_process p[64] = {{0}};
+  EXPECT_EQ(remote_wire_decode(buf, total / 2, s, g, p), 0u);
+
+  // A frame with the wrong magic is rejected.
+  uint8_t bad[1 << 16];
+  memcpy(bad, buf, total);
+  bad[4] = 'X'; // clobber the magic
+  EXPECT_EQ(remote_wire_decode(bad, total, s, g, p), 0u);
+}
+
+} // namespace


### PR DESCRIPTION
## Remote GPU telemetry: monitor your whole GPU fleet from one nvtop

This PR adds first-class **remote GPU** support to nvtop. A single
dashboard host can now aggregate live GPU stats from other machines over
TCP — turning a home/lab GPU cluster into one unified monitor.

### What it does

- **`nvtop --export [port]`** (default port 8765, `--bind <addr>`): run
  nvtop headless as a lightweight TCP exporter on any remote GPU host. It
  serves the already-populated GPU list to consumers as length-prefixed
  binary frames.
- **`gpu_vendor_remote`**: a new GPU "vendor" that dials those exporters and
  renders each remote GPU as a normal nvtop device node. It uses a 900 ms
  cache + last-good fallback (mirroring the TPU backend), so a dead remote
  host degrades gracefully and never stalls the UI.
- Config lives in the existing nvtop INI via repeating `[RemoteHost]`
  sections (`Host` / `Port` / `Name`).
- **Zero new link libraries** — pure POSIX sockets in glibc.

### Why it matters

Running a GPU across several machines (e.g. a workstation + a GPU node + a
Docker container) today means SSHing around or juggling multiple monitors.
This collapses that into **one dashboard** showing every GPU's utilization,
memory, clocks, temperature, power and per-GPU processes — live, from a
single screen.

### Wire protocol (NVT1)

Length-prefixed binary frames: a 4-byte big-endian length header followed by
little-endian payload. The `valid[]` bitmaps are forwarded verbatim so a
consumer can render absent fields as N/A with no extra logic.

### Testing

- New GTest suite (`tests/wireTest.cpp`): round-trips the wire codec
  (encode → decode) and verifies truncated-buffer / bad-magic rejection.
- The build is gated behind a new `REMOTE_SUPPORT` CMake option (default ON
  on Linux, OFF elsewhere).
